### PR TITLE
Use WriteConcern.SAFE as default for MongoDB connection

### DIFF
--- a/nosqlunit-mongodb/src/main/java/com/lordofthejars/nosqlunit/mongodb/MongoOperation.java
+++ b/nosqlunit-mongodb/src/main/java/com/lordofthejars/nosqlunit/mongodb/MongoOperation.java
@@ -17,6 +17,7 @@ import com.mongodb.DBObject;
 import com.mongodb.Mongo;
 import com.mongodb.MongoException;
 import com.mongodb.MongoOptions;
+import com.mongodb.WriteConcern;
 import com.mongodb.util.JSON;
 
 public final class MongoOperation implements DatabaseOperation<Mongo> {
@@ -34,6 +35,7 @@ public final class MongoOperation implements DatabaseOperation<Mongo> {
 	public MongoOperation(MongoDbConfiguration mongoDbConfiguration) {
 		try {
 			this.mongo = new Mongo(mongoDbConfiguration.getHost(), mongoDbConfiguration.getPort());
+			this.mongo.setWriteConcern(WriteConcern.SAFE);
 			this.mongoDbConfiguration = mongoDbConfiguration;
 		} catch (UnknownHostException e) {
 			throw new IllegalArgumentException(e);


### PR DESCRIPTION
Hi,

We are using nosql-unit to insert/read test data with remote MongoDB.
But data defined in @UsindDataSet sometimes is not available in test for reading.
The problem is that default WriteConcern in Java driver does not guarantee this - so I think it's better to always use WriteConcern.SAFE .
