### PR TITLE
Ignore all Maven target & Eclipse specific files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/.classpath
-/.project
-/.settings
-/target
+.classpath
+.project
+.settings/
+target/


### PR DESCRIPTION
Before this fix not all Maven multi-module build output directories and
Eclipse IDE specific files were ignored.

This patch fixes .gitignore to have them all properly ignored.

Issue: #68
Before this fix maven and eclipse specific files we
