### PR TITLE
Upgrade logging dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,8 +44,8 @@
 		<junit.version>4.11</junit.version>
 		<hamcrest.version>1.3</hamcrest.version>
 		<mockito.version>1.9.0</mockito.version>
-		<slf4j.version>1.6.4</slf4j.version>
-		<logback.version>0.9.24</logback.version>
+		<slf4j.version>1.7.5</slf4j.version>
+		<logback.version>1.0.11</logback.version>
 		<neo4j.version>1.8.1</neo4j.version>
 		<xmlunit.version>1.3</xmlunit.version>
 		<lambdaj.version>2.3.3</lambdaj.version>


### PR DESCRIPTION
Before this change logging dependencies were a bit outdated.

This patch bumps up versions of logging dependencies to latest ones.

Issue: #69
