### PR TITLE
DRY out surefire version

### DIFF
--- a/nosqlunit-cassandra/pom.xml
+++ b/nosqlunit-cassandra/pom.xml
@@ -54,7 +54,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.12</version>
 				<configuration>
 					<skip>true</skip>
 				</configuration>

--- a/nosqlunit-core/pom.xml
+++ b/nosqlunit-core/pom.xml
@@ -39,7 +39,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.12</version>
 				<configuration>
 					<skip>true</skip>
 				</configuration>

--- a/nosqlunit-couchdb/pom.xml
+++ b/nosqlunit-couchdb/pom.xml
@@ -29,7 +29,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.12</version>
 				<configuration>
 					<skip>true</skip>
 				</configuration>

--- a/nosqlunit-demo/pom.xml
+++ b/nosqlunit-demo/pom.xml
@@ -14,7 +14,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.12</version>
 				<configuration>
 					<excludes>
 						<exclude>**/*Test.java</exclude>

--- a/nosqlunit-hbase/pom.xml
+++ b/nosqlunit-hbase/pom.xml
@@ -51,7 +51,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.12</version>
 				<configuration>
 					<skip>true</skip>
 				</configuration>

--- a/nosqlunit-infinispan/pom.xml
+++ b/nosqlunit-infinispan/pom.xml
@@ -33,7 +33,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.12</version>
 				<configuration>
 					<skip>true</skip>
 				</configuration>

--- a/nosqlunit-mongodb/pom.xml
+++ b/nosqlunit-mongodb/pom.xml
@@ -71,7 +71,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.12</version>
 				<configuration>
 					<skip>true</skip>
 				</configuration>

--- a/nosqlunit-neo4j/pom.xml
+++ b/nosqlunit-neo4j/pom.xml
@@ -165,7 +165,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.12</version>
 				<configuration>
 					<skip>true</skip>
 				</configuration>

--- a/nosqlunit-redis/pom.xml
+++ b/nosqlunit-redis/pom.xml
@@ -51,7 +51,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.12</version>
 				<configuration>
 					<skip>true</skip>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -390,6 +390,15 @@
 						</lifecycleMappingMetadata>
 					</configuration>
 				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<version>2.14</version>
+					<configuration>
+						<forkCount>1</forkCount>
+						<reuseForks>false</reuseForks>
+					</configuration>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>


### PR DESCRIPTION
Before this change almost every submodule repeated maven surefire
plugin version.

This patch make surefire version information DRY by configuring it in
root parent pom only, and inherited by all submodules.

Issue: #70
