### PR TITLE
Configure logback as slf4j binding for tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,22 @@
 				<version>1</version>
 			</dependency>
 
+			<dependency>
+				<groupId>org.slf4j</groupId>
+				<artifactId>slf4j-api</artifactId>
+				<version>${slf4j.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>ch.qos.logback</groupId>
+				<artifactId>logback-core</artifactId>
+				<version>${logback.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>ch.qos.logback</groupId>
+				<artifactId>logback-classic</artifactId>
+				<version>${logback.version}</version>
+			</dependency>
+
 		</dependencies>
 	</dependencyManagement>
 
@@ -305,7 +321,11 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>${slf4j.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<scope>test</scope>
 		</dependency>
 
 	</dependencies>


### PR DESCRIPTION
Slf4j is used as logging api. NoSQLUnit users are supposed to provide
appropriate bindings. Because such binding was not provided to tests
in NoSQLUnit itself, build output was littered with "Failed to load
class org.slf4j.impl.StaticLoggerBinder" messages. For more info see
slf4j documentation: http://www.slf4j.org/codes.html#StaticLoggerBinder

This patch introduces logback as binding for tests in NoSQLUnit itself.

Issue: #71
