### PR TITLE
Fixed PropertyGetter and added corresponding unit test

### DIFF
--- a/nosqlunit-core/src/main/java/com/lordofthejars/nosqlunit/core/PropertyGetter.java
+++ b/nosqlunit-core/src/main/java/com/lordofthejars/nosqlunit/core/PropertyGetter.java
@@ -13,7 +13,7 @@ public class PropertyGetter <T> {
 			Field[] fields = clazz.getDeclaredFields();
 			for (Field field : fields) {
 
-				if (field.getType().isAssignableFrom(type)) {
+				if (type.isAssignableFrom(field.getType())) {
 					return (T) new FieldGetter(testInstance, field).get();
 				}
 			}

--- a/nosqlunit-core/src/test/java/com/lordofthejars/nosqlunit/core/PropertyGetterTest.java
+++ b/nosqlunit-core/src/test/java/com/lordofthejars/nosqlunit/core/PropertyGetterTest.java
@@ -1,0 +1,38 @@
+package com.lordofthejars.nosqlunit.core;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Test;
+
+public class PropertyGetterTest {
+
+	private static class TestClass {
+		List list = Arrays.asList(1, 2, 3);
+	}
+	
+	private final TestClass testInstance = new TestClass();
+	
+	@Test
+	public void propertyByType_sameTypes() {
+		PropertyGetter<List> propertyGetter = new PropertyGetter<List>();
+		assertThat(propertyGetter.propertyByType(testInstance, List.class), sameInstance(testInstance.list));
+	}
+	
+	@Test
+	public void propertyByType_findSuperType() {
+		PropertyGetter<Collection> propertyGetter = new PropertyGetter<Collection>();
+		assertThat(propertyGetter.propertyByType(testInstance, Collection.class), sameInstance((Collection) testInstance.list));
+	}
+	
+	@Test
+	public void propertyByType_findSubType() {
+		PropertyGetter<ArrayList> propertyGetter = new PropertyGetter<ArrayList>();
+		assertThat(propertyGetter.propertyByType(testInstance, ArrayList.class), nullValue());
+	}
+}


### PR DESCRIPTION
Hi Alex,

First I would like to thank you for the framework: I'm working with MongoDB at the moment and nosql-unit helps me a lot in testing.

When I was writing a test, which involves Spring MVC, I faced the following problem: MongoDB @Rule cannot wire Mongo instance from Spring context if context variable class != ApplicationContext.class. In my case variable was declared as WebApplicationContext.

After some time of looking through source code I have got an assumption that PropertyGetter doesn't handle class hierarchy very well.

I prepared a small fix.
Could you please to consider it? Hope it will be useful for the project.

Thank you,
Anton
