### PR TITLE
Enhancing manual index support with configuration in GraphML parser.

### DIFF
--- a/nosqlunit-neo4j/src/main/java/com/lordofthejars/nosqlunit/graph/parser/Edge.java
+++ b/nosqlunit-neo4j/src/main/java/com/lordofthejars/nosqlunit/graph/parser/Edge.java
@@ -10,6 +10,9 @@ import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
+import org.neo4j.helpers.collection.MapUtil;
+
+import com.google.common.base.Strings;
 
 public class Edge {
 
@@ -50,13 +53,22 @@ public class Edge {
 
 	public void createManualIndexes(GraphDatabaseService graphDatabaseService, Relationship relationship) {
 		for (ManualIndex manualIndex : manualIndexes) {
-			graphDatabaseService.index().forRelationships(manualIndex.getIndexName())
-					.add(relationship, manualIndex.getKey(), manualIndex.getValue());
+			if(manualIndex.getConfiguration() == null){
+				graphDatabaseService.index().forRelationships(manualIndex.getIndexName())
+						.add(relationship, manualIndex.getKey(), manualIndex.getValue());
+			} else {
+				graphDatabaseService.index().forRelationships(manualIndex.getIndexName(), manualIndex.getConfiguration())
+						.add(relationship, manualIndex.getKey(), manualIndex.getValue());
+			}
 		}
 	}
 
 	public void putManualIndex(String indexName, String indexKey, String indexValue) {
-		this.manualIndexes.add(new ManualIndex(indexName, indexKey, indexValue));
+		putManualIndex(indexName, indexKey, indexValue, null);
+	}
+
+	public void putManualIndex(String indexName, String indexKey, String indexValue, Map<String, String> configuration) {
+		this.manualIndexes.add(new ManualIndex(indexName, indexKey, indexValue, configuration));
 	}
 
 	public void putData(String key, Object data) {
@@ -94,12 +106,21 @@ public class Edge {
 		private String indexName;
 		private String key;
 		private String value;
+		private Map<String, String> configuration;
 
 		public ManualIndex(String indexName, String key, String value) {
 			super();
 			this.indexName = indexName;
 			this.key = key;
 			this.value = value;
+		}
+
+		public ManualIndex(String indexName, String key, String value, Map<String, String> configuration) {
+			super();
+			this.indexName = indexName;
+			this.key = key;
+			this.value = value;
+			this.configuration = configuration;
 		}
 
 		public String getIndexName() {
@@ -112,6 +133,10 @@ public class Edge {
 
 		public String getValue() {
 			return value;
+		}
+
+		public Map<String, String> getConfiguration() {
+			return configuration;
 		}
 
 	}

--- a/nosqlunit-neo4j/src/main/java/com/lordofthejars/nosqlunit/graph/parser/GraphMLReader.java
+++ b/nosqlunit-neo4j/src/main/java/com/lordofthejars/nosqlunit/graph/parser/GraphMLReader.java
@@ -14,9 +14,13 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.events.XMLEvent;
 
+import org.apache.commons.lang.StringUtils;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
+import org.neo4j.helpers.collection.MapUtil;
+
+import com.google.common.base.Strings;
 
 public class GraphMLReader {
 
@@ -180,20 +184,30 @@ public class GraphMLReader {
 							//add custom index over currentNode
 							String indexName = reader.getAttributeValue(null, GraphMLTokens.ATTR_INDEX_NAME);
 							String indexKey = reader.getAttributeValue(null, GraphMLTokens.ATTR_INDEX_KEY);
+							String indexConfiguration = reader.getAttributeValue(null, GraphMLTokens.ATTR_INDEX_CONFIGURATION);
 							String indexData = reader.getElementText();
 							
-							this.graphDatabaseService.index().forNodes(indexName).add(currentNode, indexKey, indexData);
+							if(Strings.isNullOrEmpty(indexConfiguration)) {
+								this.graphDatabaseService.index().forNodes(indexName).add(currentNode, indexKey, indexData);
+							} else {
+								String[] indexConfigurationTokens = indexConfiguration.split(GraphMLTokens.ATTR_INDEX_CONFIGURATION_SEPARATOR);
+								this.graphDatabaseService.index().forNodes(indexName, MapUtil.stringMap(indexConfigurationTokens)).add(currentNode, indexKey, indexData);
+							}
 							
 						} else {
 							if (isInsideEdgeTag(inEdge)) {
 								//add custom index over currentEdge
-								
 								String indexName = reader.getAttributeValue(null, GraphMLTokens.ATTR_INDEX_NAME);
 								String indexKey = reader.getAttributeValue(null, GraphMLTokens.ATTR_INDEX_KEY);
+								String indexConfiguration = reader.getAttributeValue(null, GraphMLTokens.ATTR_INDEX_CONFIGURATION);
 								String indexData = reader.getElementText();
 								
-								currentEdge.putManualIndex(indexName, indexKey, indexData);
-								
+								if(Strings.isNullOrEmpty(indexConfiguration)) {
+									currentEdge.putManualIndex(indexName, indexKey, indexData);
+								} else {
+									String[] indexConfigurationTokens = indexConfiguration.split(GraphMLTokens.ATTR_INDEX_CONFIGURATION_SEPARATOR);
+									currentEdge.putManualIndex(indexName, indexKey, indexData, MapUtil.stringMap(indexConfigurationTokens));
+								}
 							}
 						}
 						

--- a/nosqlunit-neo4j/src/main/java/com/lordofthejars/nosqlunit/graph/parser/GraphMLTokens.java
+++ b/nosqlunit-neo4j/src/main/java/com/lordofthejars/nosqlunit/graph/parser/GraphMLTokens.java
@@ -19,6 +19,8 @@ public class GraphMLTokens {
     public static final String ATTR_AUTOINDEX = "attr.autoindexName";
     public static final String ATTR_INDEX_NAME = "name";
     public static final String ATTR_INDEX_KEY = "key";
+    public static final String ATTR_INDEX_CONFIGURATION = "configuration";
+    public static final String ATTR_INDEX_CONFIGURATION_SEPARATOR = ",";
     public static final String INDEX = "index";
     public static final String GRAPH = "graph";
     public static final String NODE = "node";

--- a/nosqlunit-neo4j/src/test/java/com/lordofthejars/nosqlunit/graph/parser/WhenImportingGraphMLStream.java
+++ b/nosqlunit-neo4j/src/test/java/com/lordofthejars/nosqlunit/graph/parser/WhenImportingGraphMLStream.java
@@ -1,22 +1,17 @@
 package com.lordofthejars.nosqlunit.graph.parser;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.Matchers.any;
 
 import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
-import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.neo4j.graphdb.DynamicRelationshipType;
@@ -27,6 +22,7 @@ import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.index.Index;
 import org.neo4j.graphdb.index.IndexManager;
 import org.neo4j.graphdb.index.RelationshipIndex;
+import org.neo4j.helpers.collection.MapUtil;
 
 public class WhenImportingGraphMLStream {
 
@@ -361,6 +357,34 @@ public class WhenImportingGraphMLStream {
 			"    </graph>\n" + 
 			"</graphml>";
 	
+	private static final String WELL_FORMED_GRAPH_WITH_MANUAL_INDEX_WITH_CONFIGURATION_IN_NODE = "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\"\n" + 
+			"         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" + 
+			"         xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns\n" + 
+			"        http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">\n" + 
+			"    <key id=\"weight\" for=\"edge\" attr.name=\"weight\" attr.type=\"float\"/>\n" + 
+			"    <key id=\"name\" for=\"node\" attr.name=\"name\" attr.type=\"string\"/>\n" + 
+			"    <key id=\"age\" for=\"node\" attr.name=\"age\" attr.type=\"int\"/>\n" + 
+			"    <key id=\"lang\" for=\"node\" attr.name=\"lang\" attr.type=\"string\"/>\n" + 
+			"    <graph id=\"G\" edgedefault=\"directed\">\n" + 
+			"        <node id=\"15\">\n" + 
+			"            <data key=\"name\">I</data>\n" + 
+			"			 <index name=\"myindex\" key=\"mykey\" configuration=\"provider,lucene,type,fulltext\">myvalue</index>"+
+			"        </node>\n" + 
+			"        <node id=\"25\">\n" + 
+			"            <data key=\"name\">you</data>\n" + 
+			"        </node>\n" + 
+			"        <node id=\"3\">\n" + 
+			"            <data key=\"name\">him</data>\n" + 
+			"        </node>\n" + 
+			"        <edge id=\"1\" source=\"15\" target=\"25\" label=\"know\">\n" + 
+			"            <data key=\"weight\">0.5</data>\n" + 
+			"        </edge>\n" + 
+			"        <edge id=\"2\" source=\"15\" target=\"3\" label=\"know\">\n" + 
+			"            <data key=\"weight\">0.8</data>\n" + 
+			"        </edge>\n" + 
+			"    </graph>\n" + 
+			"</graphml>";
+	
 	private static final String WELL_FORMED_GRAPH_WITH_MANUAL_INDEX_IN_EDGES = "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\"\n" + 
 			"         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" + 
 			"         xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns\n" + 
@@ -382,6 +406,34 @@ public class WhenImportingGraphMLStream {
 			"        <edge id=\"1\" source=\"15\" target=\"25\" label=\"know\">\n" + 
 			"            <data key=\"weight\">0.5</data>\n" + 
 			"			 <index name=\"myindex\" key=\"mykey\">myvalue</index>"+
+			"        </edge>\n" + 
+			"        <edge id=\"2\" source=\"15\" target=\"3\" label=\"know\">\n" + 
+			"            <data key=\"weight\">0.8</data>\n" + 
+			"        </edge>\n" + 
+			"    </graph>\n" + 
+			"</graphml>";
+	
+	private static final String WELL_FORMED_GRAPH_WITH_MANUAL_INDEX_WITH_CONFIGURATION_IN_EDGES = "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\"\n" + 
+			"         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" + 
+			"         xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns\n" + 
+			"        http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">\n" + 
+			"    <key id=\"weight\" for=\"edge\" attr.name=\"weight\" attr.type=\"float\"/>\n" + 
+			"    <key id=\"name\" for=\"node\" attr.name=\"name\" attr.type=\"string\"/>\n" + 
+			"    <key id=\"age\" for=\"node\" attr.name=\"age\" attr.type=\"int\"/>\n" + 
+			"    <key id=\"lang\" for=\"node\" attr.name=\"lang\" attr.type=\"string\"/>\n" + 
+			"    <graph id=\"G\" edgedefault=\"directed\">\n" + 
+			"        <node id=\"15\">\n" + 
+			"            <data key=\"name\">I</data>\n" + 
+			"        </node>\n" + 
+			"        <node id=\"25\">\n" + 
+			"            <data key=\"name\">you</data>\n" + 
+			"        </node>\n" + 
+			"        <node id=\"3\">\n" + 
+			"            <data key=\"name\">him</data>\n" + 
+			"        </node>\n" + 
+			"        <edge id=\"1\" source=\"15\" target=\"25\" label=\"know\">\n" + 
+			"            <data key=\"weight\">0.5</data>\n" + 
+			"			 <index name=\"myindex\" key=\"mykey\" configuration=\"type,exact,to_lower_case,true\">myvalue</index>"+
 			"        </edge>\n" + 
 			"        <edge id=\"2\" source=\"15\" target=\"3\" label=\"know\">\n" + 
 			"            <data key=\"weight\">0.8</data>\n" + 
@@ -460,6 +512,46 @@ public class WhenImportingGraphMLStream {
 	}
 	
 	@Test
+	public void parser_should_create_manual_indexes_with_configuration_for_nodes() {
+		
+		Node node15 = mock(Node.class);
+		Node node25 = mock(Node.class);
+		Node node3 = mock(Node.class);
+		Node referenceNode = mock(Node.class);
+		IndexManager indexManager = mock(IndexManager.class);
+		Index<Node> index = mock(Index.class);
+		
+		when(indexManager.forNodes("myindex", MapUtil.stringMap("provider", "lucene", "type", "fulltext"))).thenReturn(index);
+		when(graphDatabaseService.index()).thenReturn(indexManager);
+		when(graphDatabaseService.getReferenceNode()).thenReturn(referenceNode);
+		when(graphDatabaseService.createNode()).thenReturn(node15).thenReturn(node25).thenReturn(node3);
+
+		Relationship relationship1 = mock(Relationship.class);
+		when(node15.createRelationshipTo(eq(node25), any(RelationshipType.class))).thenReturn(relationship1);
+
+		Relationship relationship2 = mock(Relationship.class);
+		when(node15.createRelationshipTo(eq(node3), any(RelationshipType.class))).thenReturn(relationship2);
+
+		GraphMLReader graphMLReader = new GraphMLReader(graphDatabaseService);
+		graphMLReader.read(new ByteArrayInputStream(WELL_FORMED_GRAPH_WITH_MANUAL_INDEX_WITH_CONFIGURATION_IN_NODE.getBytes()));
+
+		verify(graphDatabaseService, times(3)).createNode();
+
+		verify(node15, times(1)).createRelationshipTo(eq(node25), any(DynamicRelationshipType.class));
+		verify(node15, times(1)).createRelationshipTo(eq(node3), any(DynamicRelationshipType.class));
+
+		verify(node15).setProperty("name", "I");
+		verify(node25).setProperty("name", "you");
+		verify(node3).setProperty("name", "him");
+
+		verify(relationship1, times(1)).setProperty("weight", (Float) 0.5f);
+		verify(relationship2, times(1)).setProperty("weight", (Float) 0.8f);
+		
+		verify(index, times(1)).add(node15, "mykey", "myvalue");
+		
+	}
+	
+	@Test
 	public void parser_should_create_manual_indexes_for_relationships() {
 		
 		Node node15 = mock(Node.class);
@@ -482,6 +574,46 @@ public class WhenImportingGraphMLStream {
 
 		GraphMLReader graphMLReader = new GraphMLReader(graphDatabaseService);
 		graphMLReader.read(new ByteArrayInputStream(WELL_FORMED_GRAPH_WITH_MANUAL_INDEX_IN_EDGES.getBytes()));
+
+		verify(graphDatabaseService, times(3)).createNode();
+
+		verify(node15, times(1)).createRelationshipTo(eq(node25), any(DynamicRelationshipType.class));
+		verify(node15, times(1)).createRelationshipTo(eq(node3), any(DynamicRelationshipType.class));
+
+		verify(node15).setProperty("name", "I");
+		verify(node25).setProperty("name", "you");
+		verify(node3).setProperty("name", "him");
+
+		verify(relationship1, times(1)).setProperty("weight", (Float) 0.5f);
+		verify(relationship2, times(1)).setProperty("weight", (Float) 0.8f);
+		
+		verify(index, times(1)).add(relationship1, "mykey", "myvalue");
+		
+	}
+	
+	@Test
+	public void parser_should_create_manual_indexes_with_configuration_for_relationships() {
+		
+		Node node15 = mock(Node.class);
+		Node node25 = mock(Node.class);
+		Node node3 = mock(Node.class);
+		Node referenceNode = mock(Node.class);
+		IndexManager indexManager = mock(IndexManager.class);
+		RelationshipIndex index = mock(RelationshipIndex.class);
+		
+		when(indexManager.forRelationships("myindex", MapUtil.stringMap("type", "exact", "to_lower_case", "true"))).thenReturn(index);
+		when(graphDatabaseService.index()).thenReturn(indexManager);
+		when(graphDatabaseService.getReferenceNode()).thenReturn(referenceNode);
+		when(graphDatabaseService.createNode()).thenReturn(node15).thenReturn(node25).thenReturn(node3);
+
+		Relationship relationship1 = mock(Relationship.class);
+		when(node15.createRelationshipTo(eq(node25), any(RelationshipType.class))).thenReturn(relationship1);
+
+		Relationship relationship2 = mock(Relationship.class);
+		when(node15.createRelationshipTo(eq(node3), any(RelationshipType.class))).thenReturn(relationship2);
+
+		GraphMLReader graphMLReader = new GraphMLReader(graphDatabaseService);
+		graphMLReader.read(new ByteArrayInputStream(WELL_FORMED_GRAPH_WITH_MANUAL_INDEX_WITH_CONFIGURATION_IN_EDGES.getBytes()));
 
 		verify(graphDatabaseService, times(3)).createNode();
 


### PR DESCRIPTION
Hi Alex,

Thanks for your framework, I was happy to find an DBUnit equivalent for Neo4J !

I was stucked on a project where I needed to use Neo4J fulltext index because you can not define the index configuration in xml.
Here is a simple pull-request which allow you to define these index configurations when declaring them.
<index name="myindex" key="mykey" configuration="provider,lucene,type,fulltext">myvalue</index> will create/retrieve an index named 'myindex' with a Map configuration {provider=lucene, type=fulltext}

Regards,
Gautier
