### PR TITLE
Fixes support for DBRef insertion.

### DIFF
--- a/nosqlunit-mongodb/src/main/java/com/lordofthejars/nosqlunit/mongodb/DefaultInsertionStrategy.java
+++ b/nosqlunit-mongodb/src/main/java/com/lordofthejars/nosqlunit/mongodb/DefaultInsertionStrategy.java
@@ -8,6 +8,7 @@ import com.lordofthejars.nosqlunit.core.IOUtils;
 import com.mongodb.BasicDBList;
 import com.mongodb.BasicDBObjectBuilder;
 import com.mongodb.DB;
+import com.mongodb.DBRef;
 import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
 import com.mongodb.util.JSON;
@@ -114,7 +115,12 @@ public class DefaultInsertionStrategy implements MongoInsertionStrategy {
 		DBCollection dbCollection = mongoDb.getCollection(collectionName);
 
 		for (Object dataObject : dataObjects) {
-
+			for (String key : ((DBObject)dataObject).keySet()) {
+        Object data = ((DBObject)dataObject).get(key);
+        if (data instanceof DBRef) {
+          ((DBObject)dataObject).put(key, new DBRef(mongoDb,((DBRef)data).getRef(), ((DBRef)data).getId()));
+        }
+      }
 			dbCollection.insert((DBObject) dataObject);
 		}
 	}


### PR DESCRIPTION
As I was using nosqlunit-mongodb, I noticed a tiny bug that was specific to the use with Fongo: inserted DBRef wasn't created with a reference to the underlying DB object. I know it's up to the Java driver, as it voluntary ignore it, but without it, it can't work. So I propose this patch to feed DB on DBRefs.

Feel free to comment !
