### PR TITLE
Upgrade Jedis to 2.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .settings/
 target/
 *.iml
+.idea/

--- a/nosqlunit-redis/src/main/java/com/lordofthejars/nosqlunit/redis/embedded/EmbeddedJedis.java
+++ b/nosqlunit-redis/src/main/java/com/lordofthejars/nosqlunit/redis/embedded/EmbeddedJedis.java
@@ -10,19 +10,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import redis.clients.jedis.BinaryClient;
+import com.google.common.collect.Maps;
+import redis.clients.jedis.*;
 import redis.clients.jedis.BinaryClient.LIST_POSITION;
-import redis.clients.jedis.BinaryJedisCommands;
-import redis.clients.jedis.BinaryJedisPubSub;
-import redis.clients.jedis.JedisCommands;
-import redis.clients.jedis.JedisMonitor;
-import redis.clients.jedis.JedisPubSub;
-import redis.clients.jedis.Pipeline;
-import redis.clients.jedis.PipelineBlock;
-import redis.clients.jedis.SortingParams;
-import redis.clients.jedis.Transaction;
-import redis.clients.jedis.TransactionBlock;
-import redis.clients.jedis.Tuple;
 import redis.clients.util.Slowlog;
 import ch.lambdaj.function.convert.Converter;
 
@@ -379,7 +369,7 @@ public class EmbeddedJedis implements JedisCommands, BinaryJedisCommands {
 	}
 
 	@Override
-	public Long zadd(byte[] key, Map<Double, byte[]> scoreMembers) {
+	public Long zadd(byte[] key, Map<byte[], Double> scoreMembers) {
 		updateTtl(key);
 		checkValidTypeOrNone(key, SortsetDatatypeOperations.ZSET);
 		return this.sortsetDatatypeOperations.zadd(key, scoreMembers);
@@ -1091,8 +1081,12 @@ public class EmbeddedJedis implements JedisCommands, BinaryJedisCommands {
 	}
 
 	@Override
-	public Long zadd(String key, Map<Double, String> scoreMembers) {
-		return this.zadd(toByteArray().convert(key), with(scoreMembers).convertValues(toByteArray()));
+	public Long zadd(String key, Map<String, Double> scoreMembers) {
+		Map<byte[], Double> convertedScoreMembers = Maps.newHashMapWithExpectedSize(scoreMembers.size());
+		for (Map.Entry<String, Double> entry : scoreMembers.entrySet()) {
+			convertedScoreMembers.put(toByteArray().convert(entry.getKey()), entry.getValue());
+		}
+		return this.zadd(toByteArray().convert(key), convertedScoreMembers);
 	}
 
 	@Override
@@ -1708,6 +1702,36 @@ public class EmbeddedJedis implements JedisCommands, BinaryJedisCommands {
     @Override
     public Long bitcount(String key, long start, long end) {
         return this.bitcount(key.getBytes(), start, end);
+    }
+
+    @Override
+    public ScanResult<Map.Entry<String, String>> hscan(String s, int i) {
+        throw new UnsupportedOperationException("Sort with parameters is not supported.");
+    }
+
+    @Override
+    public ScanResult<String> sscan(String s, int i) {
+        throw new UnsupportedOperationException("Scan operations are not supported.");
+    }
+
+    @Override
+    public ScanResult<Tuple> zscan(String s, int i) {
+        throw new UnsupportedOperationException("Scan operations are not supported.");
+    }
+
+    @Override
+    public ScanResult<Map.Entry<String, String>> hscan(String s, String s2) {
+        throw new UnsupportedOperationException("Scan operations are not supported.");
+    }
+
+    @Override
+    public ScanResult<String> sscan(String s, String s2) {
+        throw new UnsupportedOperationException("Scan operations are not supported.");
+    }
+
+    @Override
+    public ScanResult<Tuple> zscan(String s, String s2) {
+        throw new UnsupportedOperationException("Scan operations are not supported.");
     }
 
     @Override

--- a/nosqlunit-redis/src/main/java/com/lordofthejars/nosqlunit/redis/embedded/SortsetDatatypeOperations.java
+++ b/nosqlunit-redis/src/main/java/com/lordofthejars/nosqlunit/redis/embedded/SortsetDatatypeOperations.java
@@ -95,22 +95,21 @@ public class SortsetDatatypeOperations extends ExpirationDatatypeOperations impl
 	 * The score value can be the string representation of a double precision
 	 * floating point number.
 	 * <p>
-	 * 
+	 *
 	 * @param key
-	 * @param score
-	 * @param member
+	 * @param scoreMembers
 	 * @return Integer reply, specifically: 1 if the new element was added 0 if
 	 *         the element was already a member of the sorted set and the score
 	 *         was updated
 	 */
-	public Long zadd(final byte[] key, final Map<Double, byte[]> scoreMembers) {
+	public Long zadd(final byte[] key, final Map<byte[], Double> scoreMembers) {
 
 		long insertedElements = 0;
 
-		Set<Entry<Double, byte[]>> scoreMemberSet = scoreMembers.entrySet();
+		Set<Entry<byte[], Double>> scoreMemberSet = scoreMembers.entrySet();
 
-		for (Entry<Double, byte[]> entry : scoreMemberSet) {
-			insertedElements += zadd(key, entry.getKey(), entry.getValue());
+		for (Entry<byte[], Double> entry : scoreMemberSet) {
+			insertedElements += zadd(key, entry.getValue(), entry.getKey());
 		}
 
 		return insertedElements;

--- a/nosqlunit-redis/src/main/java/com/lordofthejars/nosqlunit/redis/parser/DataReader.java
+++ b/nosqlunit-redis/src/main/java/com/lordofthejars/nosqlunit/redis/parser/DataReader.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.collect.Maps;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
@@ -112,12 +113,12 @@ public class DataReader {
 		Object key = sortsetObject.get(KEY_TOKEN);
 		JSONArray valuesArray = (JSONArray) sortsetObject.get(VALUES_TOKEN);
 
-		Map<Double, byte[]> scoreMembers = new HashMap<Double, byte[]>();
+		Map<byte[], Double> scoreMembers = Maps.newHashMap();
 
 		for (Object valueObject : valuesArray) {
 			JSONObject valueScopeObject = (JSONObject) valueObject;
-			scoreMembers.put(toDouble(valueScopeObject.get(SCORE_TOKEN)),
-					toByteArray(valueScopeObject.get(VALUE_TOKEN)));
+			scoreMembers.put(toByteArray(valueScopeObject.get(VALUE_TOKEN)),
+					toDouble(valueScopeObject.get(SCORE_TOKEN)));
 		}
 
 		this.jedis.zadd(toByteArray(key), scoreMembers);

--- a/nosqlunit-redis/src/test/java/com/lordofthejars/nosqlunit/redis/embedded/EmbeddedJedisUsedWithByteArray.java
+++ b/nosqlunit-redis/src/test/java/com/lordofthejars/nosqlunit/redis/embedded/EmbeddedJedisUsedWithByteArray.java
@@ -1083,8 +1083,8 @@ public class EmbeddedJedisUsedWithByteArray {
 
 		TimeUnit.MILLISECONDS.sleep(SLEEP_IN_MILLIS);
 
-		Map<Double, byte[]> elements = new HashMap<Double, byte[]>();
-		elements.put(1D, MY_JUANITA);
+		Map<byte[], Double> elements = new HashMap<byte[], Double>();
+		elements.put(MY_JUANITA, 1D);
 
 		embeddedJedis.zadd(JIVE, elements);
 		assertThat(embeddedJedis.sortsetDatatypeOperations.zcard(JIVE), is(1L));

--- a/nosqlunit-redis/src/test/java/com/lordofthejars/nosqlunit/redis/embedded/EmbeddedJedisUsedWithString.java
+++ b/nosqlunit-redis/src/test/java/com/lordofthejars/nosqlunit/redis/embedded/EmbeddedJedisUsedWithString.java
@@ -1083,8 +1083,8 @@ public class EmbeddedJedisUsedWithString {
 
 		TimeUnit.MILLISECONDS.sleep(SLEEP_IN_MILLIS);
 
-		Map<Double, String> elements = new HashMap<Double, String>();
-		elements.put(1D, SMY_JUANITA);
+		Map<String, Double> elements = new HashMap<String, Double>();
+		elements.put(SMY_JUANITA, 1D);
 
 		embeddedJedis.zadd(SJIVE, elements);
 		assertThat(embeddedJedis.sortsetDatatypeOperations.zcard(JIVE), is(1L));

--- a/nosqlunit-redis/src/test/java/com/lordofthejars/nosqlunit/redis/embedded/WhenEmbeddedSortsetOperationsAreExecuted.java
+++ b/nosqlunit-redis/src/test/java/com/lordofthejars/nosqlunit/redis/embedded/WhenEmbeddedSortsetOperationsAreExecuted.java
@@ -50,11 +50,11 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zadd_should_add_multiple_fields_ordered_by_score() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(3D, GUITAR);
-		groupMembers.put(4D, DRUMER);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(GUITAR, 3D);
+		groupMembers.put(DRUMER, 4D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
 		
 		long result = sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		assertThat(result, is(4L));
@@ -72,19 +72,19 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zadd_should_update_score_if_member_already_exists() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(3D, GUITAR);
-		groupMembers.put(4D, DRUMER);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(5D, VOCALIST);
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(GUITAR, 3D);
+		groupMembers.put(DRUMER, 4D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 5D);
 		
 		long result = sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		assertThat(result, is(4L));
 		
-		Map<Double, byte[]> newGroupMembers = new HashMap<Double, byte[]>();
-
-		newGroupMembers.put(1D, VOCALIST);
-		newGroupMembers.put(6D, KEYBOARD);
+		Map<byte[], Double> newGroupMembers = new HashMap<byte[], Double>();
+		
+		newGroupMembers.put(VOCALIST, 1D);
+		newGroupMembers.put(KEYBOARD, 6D);
 		
 		result = sortsetDatatypeOperations.zadd(GROUP_NAME, newGroupMembers);
 		assertThat(result, is(1L));
@@ -104,12 +104,11 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zcard_should_count_number_of_elements() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(3D, GUITAR);
-		groupMembers.put(4D, DRUMER);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-	
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(GUITAR, 3D);
+		groupMembers.put(DRUMER, 4D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
 		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
@@ -120,12 +119,11 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zcard_should_count_0_if_no_key() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(3D, GUITAR);
-		groupMembers.put(4D, DRUMER);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-	
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(GUITAR, 3D);
+		groupMembers.put(DRUMER, 4D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
 		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
@@ -136,11 +134,11 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zcount_should_count_number_of_elements_between_inclusive_score() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(3D, GUITAR);
-		groupMembers.put(4D, DRUMER);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(GUITAR, 3D);
+		groupMembers.put(DRUMER, 4D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
 		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
@@ -153,11 +151,11 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zcount_should_count_number_of_elements_between_exclusive_score() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(3D, GUITAR);
-		groupMembers.put(4D, DRUMER);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(GUITAR, 3D);
+		groupMembers.put(DRUMER, 4D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
 		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
@@ -170,11 +168,11 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zcount_should_count_number_of_elements_with_infinite_score() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(3D, GUITAR);
-		groupMembers.put(4D, DRUMER);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(GUITAR, 3D);
+		groupMembers.put(DRUMER, 4D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
 		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
@@ -187,8 +185,7 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zcount_should_count_zero_if_no_elements_found() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
 		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
@@ -201,11 +198,11 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zincrby_should_increment_score_of_element() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(3D, GUITAR);
-		groupMembers.put(4D, DRUMER);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(GUITAR, 3D);
+		groupMembers.put(DRUMER, 4D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
 		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
@@ -226,10 +223,10 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zincrby_should_add_element_if_member_is_not_present() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(4D, DRUMER);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 4D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
 		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
@@ -249,10 +246,10 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zincrby_should_add_element_if_key_is_not_present() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(4D, DRUMER);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 4D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
 		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
@@ -273,18 +270,18 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zunionstore_should_store_union_of_elements_with_sum_score_by_default() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(4D, DRUMER);
-		groupMembers.put(3D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 4D);
+		groupMembers.put(GUITAR, 3D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
-		Map<Double, byte[]> newGroupMembers = new HashMap<Double, byte[]>();
-		newGroupMembers.put(4D, DRUMER);
-		newGroupMembers.put(3D, GUITAR);
-		newGroupMembers.put(5D, SUBSTITUTE_OF_FREDDIE);
+		Map<byte[], Double> newGroupMembers = new HashMap<byte[], Double>();
+		newGroupMembers.put(DRUMER, 4D);
+		newGroupMembers.put(GUITAR, 3D);
+		newGroupMembers.put(SUBSTITUTE_OF_FREDDIE, 5D);
 		
 		sortsetDatatypeOperations.zadd(NEW_GROUP_NAME, newGroupMembers);
 		
@@ -305,23 +302,23 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zunionstore_should_overwrite_union_of_elements_with_sum_score_by_default() {
 		
-		Map<Double, byte[]> allMembers = new HashMap<Double, byte[]>();
-		allMembers.put(4D, KEYBOARD);
+		Map<byte[], Double> allMembers = new HashMap<byte[], Double>();
+		allMembers.put(KEYBOARD, 4D);
 		
 		sortsetDatatypeOperations.zadd(ALL_QUEEN, allMembers);
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(4D, DRUMER);
-		groupMembers.put(3D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 4D);
+		groupMembers.put(GUITAR, 3D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
-		Map<Double, byte[]> newGroupMembers = new HashMap<Double, byte[]>();
-		newGroupMembers.put(4D, DRUMER);
-		newGroupMembers.put(3D, GUITAR);
-		newGroupMembers.put(5D, SUBSTITUTE_OF_FREDDIE);
+		Map<byte[], Double> newGroupMembers = new HashMap<byte[], Double>();
+		newGroupMembers.put(DRUMER, 4D);
+		newGroupMembers.put(GUITAR, 3D);
+		newGroupMembers.put(SUBSTITUTE_OF_FREDDIE, 5D);
 		
 		sortsetDatatypeOperations.zadd(NEW_GROUP_NAME, newGroupMembers);
 		
@@ -342,18 +339,18 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zunionstore_should_store_union_of_elements_with_sum_of_weighted_score() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(4D, DRUMER);
-		groupMembers.put(3D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 4D);
+		groupMembers.put(GUITAR, 3D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
-		Map<Double, byte[]> newGroupMembers = new HashMap<Double, byte[]>();
-		newGroupMembers.put(3D, DRUMER);
-		newGroupMembers.put(2D, GUITAR);
-		newGroupMembers.put(1D, SUBSTITUTE_OF_FREDDIE);
+		Map<byte[], Double> newGroupMembers = new HashMap<byte[], Double>();
+		newGroupMembers.put(DRUMER, 3D);
+		newGroupMembers.put(GUITAR, 2D);
+		newGroupMembers.put(SUBSTITUTE_OF_FREDDIE, 1D);
 		
 		sortsetDatatypeOperations.zadd(NEW_GROUP_NAME, newGroupMembers);
 		
@@ -377,18 +374,18 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zunionstore_should_store_union_of_elements_with_min_score() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(7D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 7D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
-		Map<Double, byte[]> newGroupMembers = new HashMap<Double, byte[]>();
-		newGroupMembers.put(3D, DRUMER);
-		newGroupMembers.put(4D, GUITAR);
-		newGroupMembers.put(8D, SUBSTITUTE_OF_FREDDIE);
+		Map<byte[], Double> newGroupMembers = new HashMap<byte[], Double>();
+		newGroupMembers.put(DRUMER, 3D);
+		newGroupMembers.put(GUITAR, 4D);
+		newGroupMembers.put(SUBSTITUTE_OF_FREDDIE, 8D);
 		
 		sortsetDatatypeOperations.zadd(NEW_GROUP_NAME, newGroupMembers);
 		
@@ -412,18 +409,18 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zunionstore_should_store_union_of_elements_with_max_score() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(7D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 7D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
-		Map<Double, byte[]> newGroupMembers = new HashMap<Double, byte[]>();
-		newGroupMembers.put(3D, DRUMER);
-		newGroupMembers.put(4D, GUITAR);
-		newGroupMembers.put(8D, SUBSTITUTE_OF_FREDDIE);
+		Map<byte[], Double> newGroupMembers = new HashMap<byte[], Double>();
+		newGroupMembers.put(DRUMER, 3D);
+		newGroupMembers.put(GUITAR, 4D);
+		newGroupMembers.put(SUBSTITUTE_OF_FREDDIE, 8D);
 		
 		sortsetDatatypeOperations.zadd(NEW_GROUP_NAME, newGroupMembers);
 		
@@ -447,18 +444,18 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zunionstore_should_store_union_of_elements_with_aggregation_and_weights() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(7D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 7D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
-		Map<Double, byte[]> newGroupMembers = new HashMap<Double, byte[]>();
-		newGroupMembers.put(3D, DRUMER);
-		newGroupMembers.put(4D, GUITAR);
-		newGroupMembers.put(8D, SUBSTITUTE_OF_FREDDIE);
+		Map<byte[], Double> newGroupMembers = new HashMap<byte[], Double>();
+		newGroupMembers.put(DRUMER, 3D);
+		newGroupMembers.put(GUITAR, 4D);
+		newGroupMembers.put(SUBSTITUTE_OF_FREDDIE, 8D);
 		
 		sortsetDatatypeOperations.zadd(NEW_GROUP_NAME, newGroupMembers);
 		
@@ -483,18 +480,18 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test(expected=IllegalArgumentException.class)
 	public void zunionstore_should_store_union_of_elements_with_invalid_weights() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(7D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 7D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
-		Map<Double, byte[]> newGroupMembers = new HashMap<Double, byte[]>();
-		newGroupMembers.put(3D, DRUMER);
-		newGroupMembers.put(4D, GUITAR);
-		newGroupMembers.put(8D, SUBSTITUTE_OF_FREDDIE);
+		Map<byte[], Double> newGroupMembers = new HashMap<byte[], Double>();
+		newGroupMembers.put(DRUMER, 3D);
+		newGroupMembers.put(GUITAR, 4D);
+		newGroupMembers.put(SUBSTITUTE_OF_FREDDIE, 8D);
 		
 		sortsetDatatypeOperations.zadd(NEW_GROUP_NAME, newGroupMembers);
 		
@@ -508,18 +505,18 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zinterstore_should_store_union_of_elements_with_aggregation_and_weights() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(7D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 7D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
-		Map<Double, byte[]> newGroupMembers = new HashMap<Double, byte[]>();
-		newGroupMembers.put(3D, DRUMER);
-		newGroupMembers.put(4D, GUITAR);
-		newGroupMembers.put(8D, SUBSTITUTE_OF_FREDDIE);
+		Map<byte[], Double> newGroupMembers = new HashMap<byte[], Double>();
+		newGroupMembers.put(DRUMER, 3D);
+		newGroupMembers.put(GUITAR, 4D);
+		newGroupMembers.put(SUBSTITUTE_OF_FREDDIE, 8D);
 		
 		sortsetDatatypeOperations.zadd(NEW_GROUP_NAME, newGroupMembers);
 		
@@ -541,11 +538,11 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrange_should_return_elements_between_range() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<byte[]> lastElement = sortsetDatatypeOperations.zrange(GROUP_NAME, 2, 3);
@@ -558,12 +555,12 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrange_should_return_elements_between_range_inclusive() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(4D, DRUMER);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(DRUMER, 4D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<byte[]> lastElement = sortsetDatatypeOperations.zrange(GROUP_NAME, 1, 3);
@@ -576,11 +573,11 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrange_should_return_all_elements_between_range() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<byte[]> allElements = sortsetDatatypeOperations.zrange(GROUP_NAME, 0, -1);
@@ -593,11 +590,11 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrange_should_return_elements_between_negative_range() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<byte[]> elements = sortsetDatatypeOperations.zrange(GROUP_NAME, -2, -1);
@@ -610,11 +607,11 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrange_should_return_elements_between_negative_and_positives_range() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<byte[]> elements = sortsetDatatypeOperations.zrange(GROUP_NAME, 1, -2);
@@ -627,11 +624,11 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrange_should_return_all_scored_elements_between_range() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<ScoredByteBuffer> allElements = sortsetDatatypeOperations.zrangeWithScores(GROUP_NAME, 0, -1);
@@ -648,11 +645,11 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrange_by_score_should_return_all_elements_between_score() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<byte[]> allElements = sortsetDatatypeOperations.zrangeByScore(GROUP_NAME, 0, 6);
@@ -665,11 +662,11 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrange_by_score_should_return_no_elements_scores_outside_range() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<byte[]> allElements = sortsetDatatypeOperations.zrangeByScore(GROUP_NAME, 7, 10);
@@ -681,11 +678,11 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrange_by_score_should_return_all_elements_with_infinite_scores() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<byte[]> allElements = sortsetDatatypeOperations.zrangeByScore(GROUP_NAME, "-inf".getBytes(), "+inf".getBytes());
@@ -698,11 +695,11 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrange_by_score_should_return_all_elements_with_exclusive_scores() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<byte[]> allElements = sortsetDatatypeOperations.zrangeByScore(GROUP_NAME, "(1".getBytes(), "(5".getBytes());
@@ -715,11 +712,11 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrange_by_score_should_return_elements_with_exclusive_min_outrange_scores() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<byte[]> allElements = sortsetDatatypeOperations.zrangeByScore(GROUP_NAME, "(0".getBytes(), "(5".getBytes());
@@ -732,11 +729,11 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrange_by_score_should_return_no_elements_with_exclusive_max_outrange_scores() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<byte[]> allElements = sortsetDatatypeOperations.zrangeByScore(GROUP_NAME, "(-2".getBytes(), "(-1".getBytes());
@@ -748,11 +745,11 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrange_by_score_should_return_no_elements_with_inverted_min_max_outrange_scores() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<byte[]> allElements = sortsetDatatypeOperations.zrangeByScore(GROUP_NAME, 2, 0);
@@ -764,12 +761,12 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrange_by_score_should_return_elements_limited_by_offset() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<byte[]> allElements = sortsetDatatypeOperations.zrangeByScore(GROUP_NAME, 0, 6, 1, 2);
@@ -781,12 +778,12 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrange_by_score_should_return_elements_limited_by_offset_and_outrange_count() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<byte[]> allElements = sortsetDatatypeOperations.zrangeByScore(GROUP_NAME, 0, 6, 2, 10);
@@ -798,12 +795,12 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrange_by_score_should_return_elements_limited_by_offset_and_negative_count() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<byte[]> allElements = sortsetDatatypeOperations.zrangeByScore(GROUP_NAME, 0, 6, 2, -10);
@@ -815,12 +812,12 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrange_by_score_should_return_no_elements_limited_by_offset_greater_than_number_elements() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<byte[]> allElements = sortsetDatatypeOperations.zrangeByScore(GROUP_NAME, 0, 6, 10, -10);
@@ -832,12 +829,12 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrange_by_score_should_return_elements_limited_by_offset_with_infintie_parameter() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<byte[]> allElements = sortsetDatatypeOperations.zrangeByScore(GROUP_NAME, "-inf".getBytes(), "+inf".getBytes(), 1, 3);
@@ -849,12 +846,12 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrange_by_score_should_return_elements_limited_with_exclusive_parameters() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<byte[]> allElements = sortsetDatatypeOperations.zrangeByScore(GROUP_NAME, "(0".getBytes(), "(2".getBytes(), 0, 1);
@@ -866,12 +863,12 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrange_by_score_should_return_elements_limited_by_offset_and_outrange_count_with_infinite_count() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<byte[]> allElements = sortsetDatatypeOperations.zrangeByScore(GROUP_NAME, "1".getBytes(), "+inf".getBytes(), 0, 10);
@@ -884,11 +881,11 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrange_by_score_with_score_should_return_all_elements_between_score() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<ScoredByteBuffer> allElements = sortsetDatatypeOperations.zrangeByScoreWithScores(GROUP_NAME, 0, 6);
@@ -905,11 +902,11 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrange_by_score_with_score_should_return_no_elements_scores_outside_range() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<ScoredByteBuffer> allElements = sortsetDatatypeOperations.zrangeByScoreWithScores(GROUP_NAME, 7, 10);
@@ -921,11 +918,11 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrange_by_score_with_score_should_return_all_elements_with_infinite_scores() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<ScoredByteBuffer> allElements = sortsetDatatypeOperations.zrangeByScoreWithScores(GROUP_NAME, "-inf".getBytes(), "+inf".getBytes());
@@ -942,11 +939,11 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrange_by_score_with_score_should_return_all_elements_with_exclusive_scores() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<ScoredByteBuffer> allElements = sortsetDatatypeOperations.zrangeByScoreWithScores(GROUP_NAME, "(1".getBytes(), "(5".getBytes());
@@ -961,11 +958,11 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrange_by_score__with_score_should_return_elements_with_exclusive_min_outrange_scores() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<ScoredByteBuffer> allElements = sortsetDatatypeOperations.zrangeByScoreWithScores(GROUP_NAME, "(0".getBytes(), "(5".getBytes());
@@ -981,11 +978,11 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrange_by_score_with_score_should_return_no_elements_with_exclusive_max_outrange_scores() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<ScoredByteBuffer> allElements = sortsetDatatypeOperations.zrangeByScoreWithScores(GROUP_NAME, "(-2".getBytes(), "(-1".getBytes());
@@ -997,11 +994,11 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrange_by_score__with_score_should_return_no_elements_with_inverted_min_max_outrange_scores() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<ScoredByteBuffer> allElements = sortsetDatatypeOperations.zrangeByScoreWithScores(GROUP_NAME, 2, 0);
@@ -1013,12 +1010,12 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrange_by_score_with_score_should_return_elements_limited_by_offset() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<ScoredByteBuffer> allElements = sortsetDatatypeOperations.zrangeByScoreWithScores(GROUP_NAME, 0, 6, 1, 2);
@@ -1033,12 +1030,12 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrange_by_score_with_score_should_return_elements_limited_by_offset_and_outrange_count() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<ScoredByteBuffer> allElements = sortsetDatatypeOperations.zrangeByScoreWithScores(GROUP_NAME, 0, 6, 2, 10);
@@ -1053,12 +1050,12 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrange_by_score_with_score_should_return_elements_limited_by_offset_and_negative_count() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<ScoredByteBuffer> allElements = sortsetDatatypeOperations.zrangeByScoreWithScores(GROUP_NAME, 0, 6, 2, -10);
@@ -1073,12 +1070,12 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrange_by_score__with_score_should_return_no_elements_limited_by_offset_greater_than_number_elements() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<ScoredByteBuffer> allElements = sortsetDatatypeOperations.zrangeByScoreWithScores(GROUP_NAME, 0, 6, 10, -10);
@@ -1090,12 +1087,12 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrange_by_score_with_score_should_return_elements_limited_by_offset_with_infintie_parameter() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<ScoredByteBuffer> allElements = sortsetDatatypeOperations.zrangeByScoreWithScores(GROUP_NAME, "-inf".getBytes(), "+inf".getBytes(), 1, 3);
@@ -1111,12 +1108,12 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrange_by_score_with_score_should_return_elements_limited_with_exclusive_parameters() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<ScoredByteBuffer> allElements = sortsetDatatypeOperations.zrangeByScoreWithScores(GROUP_NAME, "(0".getBytes(), "(2".getBytes(), 0, 1);
@@ -1130,12 +1127,12 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrange_by_score_with_score_should_return_elements_limited_by_offset_and_outrange_count_with_infinite_count() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<ScoredByteBuffer> allElements = sortsetDatatypeOperations.zrangeByScoreWithScores(GROUP_NAME, "1".getBytes(), "+inf".getBytes(), 0, 10);
@@ -1152,12 +1149,12 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrank_should_return_index_of_given_element() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Long index = sortsetDatatypeOperations.zrank(GROUP_NAME, GUITAR);
@@ -1168,12 +1165,12 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrank_should_return_null_if_key_not_found() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Long index = sortsetDatatypeOperations.zrank(NEW_GROUP_NAME, GUITAR);
@@ -1184,12 +1181,12 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrank_should_return_null_if_element_not_found() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Long index = sortsetDatatypeOperations.zrank(GROUP_NAME, KEYBOARD);
@@ -1200,12 +1197,12 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrem_should_remove_all_passed_elements() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Long removedElements = sortsetDatatypeOperations.zrem(GROUP_NAME, GUITAR, VOCALIST);
@@ -1219,12 +1216,12 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrem_should_not_remove_elements_of_none_existing_key() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Long removedElements = sortsetDatatypeOperations.zrem(NEW_GROUP_NAME, GUITAR, VOCALIST);
@@ -1238,12 +1235,12 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrem_should_not_remove_elements_not_present() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Long removedElements = sortsetDatatypeOperations.zrem(GROUP_NAME, GUITAR, KEYBOARD);
@@ -1257,12 +1254,12 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zremrangeByRank_should_remove_elements_by_rank() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Long removedElements = sortsetDatatypeOperations.zremrangeByRank(GROUP_NAME, 1, 2);
@@ -1273,7 +1270,7 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 		
 		ScoredByteBuffer vocalist = ScoredByteBuffer.createScoredByteBuffer(wrap(VOCALIST), 1D);
 		ScoredByteBuffer drumer = ScoredByteBuffer.createScoredByteBuffer(wrap(DRUMER), 6D);
-
+	
 		assertThat(orderedMembers, contains(vocalist, drumer));
 		
 	}
@@ -1281,12 +1278,12 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zremrangeByRank_should_remove_all_elements_using_negative_ranks() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Long removedElements = sortsetDatatypeOperations.zremrangeByRank(GROUP_NAME, 0, -1);
@@ -1300,12 +1297,12 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zremrangeByScore_should_remove_elements_between_score() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Long removedElements = sortsetDatatypeOperations.zremrangeByScore(GROUP_NAME, 2, 4);
@@ -1324,12 +1321,12 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zremrangeByScore_should_remove_elements_between_infinite_score() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Long removedElements = sortsetDatatypeOperations.zremrangeByScore(GROUP_NAME, "-inf".getBytes(), "2".getBytes());
@@ -1347,11 +1344,11 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrevrange_should_return_reverse_elements_between_range() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<byte[]> lastElement = sortsetDatatypeOperations.zrange(GROUP_NAME, 2, 3);
@@ -1364,12 +1361,12 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrevrange_should_return_inverted_elements_between_range_inclusive() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(1D, VOCALIST);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(4D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(VOCALIST, 1D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(DRUMER, 4D);
+		groupMembers.put(GUITAR, 5D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<byte[]> lastElement = sortsetDatatypeOperations.zrevrange(GROUP_NAME, 1, 3);
@@ -1382,11 +1379,11 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrevrange_should_return_all_inverted_elements_between_range() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<byte[]> allElements = sortsetDatatypeOperations.zrevrange(GROUP_NAME, 0, -1);
@@ -1395,15 +1392,15 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 		assertThat(allElements, contains(GUITAR, BASSIST, VOCALIST));
 		
 	}
-	
+		
 	@Test
 	public void zrevrange_should_return_inverted_elements_between_negative_range() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<byte[]> elements = sortsetDatatypeOperations.zrevrange(GROUP_NAME, -2, -1);
@@ -1412,15 +1409,15 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 		assertThat(elements, contains(BASSIST, VOCALIST));
 		
 	}
-	
+		
 	@Test
 	public void zrevrange_should_return_inverted_elements_between_negative_and_positives_range() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<byte[]> elements = sortsetDatatypeOperations.zrevrange(GROUP_NAME, 1, -2);
@@ -1429,35 +1426,35 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 		assertThat(elements, contains(BASSIST));
 		
 	}
-	
+		
 	@Test
 	public void zrevrange_should_return_inverted_elements_between_negative_and_positives_range_with_scores() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
-		
+	
 		Set<ScoredByteBuffer> elements = sortsetDatatypeOperations.zrevrangeWithScores(GROUP_NAME, 1, -2);
-		
+	
 		ScoredByteBuffer bassist = ScoredByteBuffer.createScoredByteBuffer(wrap(BASSIST), 2D);
-		
+	
 		assertThat(elements, hasSize(1));
 		assertThat(elements, contains(bassist));
-		
+	
 	}
 	
 	@Test
 	public void zrevrangeByScore_should_return_inverted_elements_between_scope_number() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(1D, VOCALIST);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(7D, KEYBOARD);
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(VOCALIST, 1D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(KEYBOARD, 7D);
 		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
@@ -1471,14 +1468,14 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	
 	@Test
 	public void zrevrangeByScore_should_return_inverted_elements_between_infinite_scope() {
-		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(7D, KEYBOARD);
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+	
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(KEYBOARD, 7D);
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+	
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<byte[]> zrevrangeByScore = sortsetDatatypeOperations.zrevrangeByScore(GROUP_NAME, "+inf".getBytes(), "-inf".getBytes());
@@ -1490,14 +1487,14 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	
 	@Test
 	public void zrevrangeByScore_should_return_inverted_elements_with_exclusive_scope() {
-		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(7D, KEYBOARD);
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+	
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(KEYBOARD, 7D);
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+	
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<byte[]> zrevrangeByScore = sortsetDatatypeOperations.zrevrangeByScore(GROUP_NAME, "2".getBytes(), "(1	".getBytes());
@@ -1510,13 +1507,13 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrevrangeByScore_should_return_empty_elements_with_consecutive_exclusive_scope() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(7D, KEYBOARD);
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(KEYBOARD, 7D);
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<byte[]> zrevrangeByScore = sortsetDatatypeOperations.zrevrangeByScore(GROUP_NAME, "(2".getBytes(), "(1	".getBytes());
@@ -1527,13 +1524,13 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrevrangeByScore_should_return_inverted_elements_between_range_scope_with_limit() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(1D, VOCALIST);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(7D, KEYBOARD);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(VOCALIST, 1D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(KEYBOARD, 7D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<byte[]> zrevrangeByScore = sortsetDatatypeOperations.zrevrangeByScore(GROUP_NAME, 5, 0, 1, 2);
@@ -1546,13 +1543,13 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrevrangeByScore_should_return_inverted_elements_between_infinite_scope_with_limit() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(1D, VOCALIST);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(7D, KEYBOARD);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(VOCALIST, 1D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(KEYBOARD, 7D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<byte[]> zrevrangeByScore = sortsetDatatypeOperations.zrevrangeByScore(GROUP_NAME, "+inf".getBytes(), "-inf".getBytes(), 1, 2);
@@ -1565,13 +1562,13 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrevrangeByScore_should_return_inverted_elements_between_range_scope_with_limit_and_score() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(1D, VOCALIST);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(7D, KEYBOARD);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(VOCALIST, 1D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(KEYBOARD, 7D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<ScoredByteBuffer> zrevrangeByScore = sortsetDatatypeOperations.zrevrangeByScoreWithScores(GROUP_NAME, 5, 0, 1, 2);
@@ -1587,13 +1584,13 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrevrangeByScore_should_return_inverted_elements_between_infinite_scope_with_limit_and_score() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(1D, VOCALIST);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(7D, KEYBOARD);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(VOCALIST, 1D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(KEYBOARD, 7D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<ScoredByteBuffer> zrevrangeByScore = sortsetDatatypeOperations.zrevrangeByScoreWithScores(GROUP_NAME, "+inf".getBytes(), "-inf".getBytes(), 1, 2);
@@ -1609,13 +1606,13 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrevrangeByScore_should_return_inverted_elements_between_range_scope_and_score() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(1D, VOCALIST);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(7D, KEYBOARD);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(VOCALIST, 1D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(KEYBOARD, 7D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<ScoredByteBuffer> zrevrangeByScore = sortsetDatatypeOperations.zrevrangeByScoreWithScores(GROUP_NAME, 5, 0);
@@ -1632,13 +1629,13 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrevrangeByScore_should_return_inverted_elements_between_infinite_scope_and_score() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(1D, VOCALIST);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(7D, KEYBOARD);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(VOCALIST, 1D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(KEYBOARD, 7D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Set<ScoredByteBuffer> zrevrangeByScore = sortsetDatatypeOperations.zrevrangeByScoreWithScores(GROUP_NAME, "+inf".getBytes(), "-inf".getBytes());
@@ -1657,12 +1654,12 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrevrank_should_return_index_of_given_element() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Long index = sortsetDatatypeOperations.zrevrank(GROUP_NAME, GUITAR);
@@ -1673,12 +1670,12 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrevrank_should_return_null_if_key_not_found() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Long index = sortsetDatatypeOperations.zrank(NEW_GROUP_NAME, GUITAR);
@@ -1689,12 +1686,12 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zrevrank_should_return_null_if_element_not_found() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Long index = sortsetDatatypeOperations.zrank(GROUP_NAME, KEYBOARD);
@@ -1705,12 +1702,12 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zscore_should_return_the_score_of_member() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Double score = sortsetDatatypeOperations.zscore(GROUP_NAME, GUITAR);
@@ -1721,12 +1718,12 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zscore_should_return_null_if_member_does_not_exist() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Double score = sortsetDatatypeOperations.zscore(GROUP_NAME, KEYBOARD);
@@ -1737,12 +1734,12 @@ public class WhenEmbeddedSortsetOperationsAreExecuted {
 	@Test
 	public void zscore_should_return_null_if_key_does_not_exist() {
 		
-		Map<Double, byte[]> groupMembers = new HashMap<Double, byte[]>();
-		groupMembers.put(6D, DRUMER);
-		groupMembers.put(5D, GUITAR);
-		groupMembers.put(2D, BASSIST);
-		groupMembers.put(1D, VOCALIST);
-
+		Map<byte[], Double> groupMembers = new HashMap<byte[], Double>();
+		groupMembers.put(DRUMER, 6D);
+		groupMembers.put(GUITAR, 5D);
+		groupMembers.put(BASSIST, 2D);
+		groupMembers.put(VOCALIST, 1D);
+		
 		sortsetDatatypeOperations.zadd(GROUP_NAME, groupMembers);
 		
 		Double score = sortsetDatatypeOperations.zscore(NEW_GROUP_NAME, GUITAR);

--- a/nosqlunit-redis/src/test/java/com/lordofthejars/nosqlunit/redis/parser/WhenRedisDataIsImported.java
+++ b/nosqlunit-redis/src/test/java/com/lordofthejars/nosqlunit/redis/parser/WhenRedisDataIsImported.java
@@ -341,9 +341,9 @@ public class WhenRedisDataIsImported {
 		ArgumentCaptor<Map> argument = ArgumentCaptor.forClass(Map.class);
 		verify(jedis).zadd(eq("key".getBytes()), argument.capture());
 
-		byte[] objectValue1 = (byte[]) argument.getValue().get(1.0);
+		byte[] objectValue1 = (byte[]) firstKeyForValue(argument.getValue(), 1.0);
 		assertThat(objectValue1, is("value1".getBytes()));
-		byte[] objectValue2 = (byte[]) argument.getValue().get(2.0);
+		byte[] objectValue2 = (byte[]) firstKeyForValue(argument.getValue(), 2.0);
 		assertThat(objectValue2, is("value2".getBytes()));
 	}
 	
@@ -360,9 +360,9 @@ public class WhenRedisDataIsImported {
 		ArgumentCaptor<Map> argument = ArgumentCaptor.forClass(Map.class);
 		verify(jedis).zadd(eq("key".getBytes()), argument.capture());
 
-		byte[] objectValue1 = (byte[]) argument.getValue().get(1.0);
+		byte[] objectValue1 = (byte[]) firstKeyForValue(argument.getValue(), 1.0);
 		assertThat(objectValue1, is("value1".getBytes()));
-		byte[] objectValue2 = (byte[]) argument.getValue().get(2.0);
+		byte[] objectValue2 = (byte[]) firstKeyForValue(argument.getValue(), 2.0);
 		assertThat(objectValue2, is("value2".getBytes()));
 	}
 	
@@ -376,5 +376,12 @@ public class WhenRedisDataIsImported {
 		
 		return bytes;
 	}
-	
+
+	private <K, V> K firstKeyForValue(Map<K, V> map, V value) {
+		for (Map.Entry<K, V> entry : map.entrySet()) {
+			if (value.equals(entry.getValue()))
+				return entry.getKey();
+		}
+		return null;
+	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 		<stax.version>1.0.1</stax.version>
 		<hamcrest.xml.version>0.10</hamcrest.xml.version>
 		<cassandra.unit.version>1.1.2.1</cassandra.unit.version>
-		<jedis.version>2.2.1</jedis.version>
+		<jedis.version>2.4.0</jedis.version>
 		<json.simple.version>1.1.1</json.simple.version>
 		<guava.version>13.0.1</guava.version>
 		<jsr.305.version>1.3.9</jsr.305.version>


### PR DESCRIPTION
Updated zadd methods for DataReader and EmbeddeJedis to be compatible with Jedis 2.3+
Added unimplemented scan methods to EmbeddedJedis to be compatible with Jedis 2.4+
