### PR TITLE
Implemented flexible comparison strategy for MongoDB

### DIFF
--- a/nosqlunit-mongodb/src/main/java/com/lordofthejars/nosqlunit/mongodb/MongoDbAssertion.java
+++ b/nosqlunit-mongodb/src/main/java/com/lordofthejars/nosqlunit/mongodb/MongoDbAssertion.java
@@ -1,22 +1,24 @@
 package com.lordofthejars.nosqlunit.mongodb;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import com.lordofthejars.nosqlunit.core.FailureHandler;
-import com.mongodb.BasicDBList;
-import com.mongodb.DB;
-import com.mongodb.DBCollection;
-import com.mongodb.DBObject;
+import com.mongodb.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 
 public class MongoDbAssertion {
 
 	private static final String SYSTEM_COLLECTIONS_PATTERN = "system."; 
 	private static final String DATA = "data";
-	
-	private MongoDbAssertion() {
-		super();
+
+    private static final Logger logger = LoggerFactory.getLogger(MongoDbAssertion.class);
+
+    private MongoDbAssertion() {
+        super();
 	}
 	
 	public static final void strictAssertEquals(DBObject expectedData, DB mongoDb) {
@@ -91,10 +93,9 @@ public class MongoDbAssertion {
 			
 			DBObject expectedDataObject = (DBObject)dataObject;
 			DBObject foundObject = dbCollection.findOne(expectedDataObject);
-			
-			
-			
-			if(!exists(foundObject)) {
+
+
+            if(!exists(foundObject)) {
 				throw FailureHandler.createFailure("Object # %s # is not found into collection %s", expectedDataObject.toString(), collectionaNames);
 			}
 
@@ -140,5 +141,153 @@ public class MongoDbAssertion {
 		return foundObject != null;
 	}
 
-	
+    //<editor-fold desc="Flexible comparator">
+
+    /**
+     * Checks that all the expected data is present in MongoDB.
+     *
+     * @param expectedData Expected data.
+     * @param mongoDb      Mongo Database.
+     */
+    public static void flexibleAssertEquals(DBObject expectedData, DB mongoDb) {
+        // Get the expected collections
+        Set<String> collectionNames = expectedData.keySet();
+
+        // Get the current collections in mongoDB
+        Set<String> mongodbCollectionNames = mongoDb.getCollectionNames();
+
+        // Check expected data
+        flexibleCheckCollectionsName(collectionNames, mongodbCollectionNames);
+        for (String collectionName : collectionNames) {
+            flexibleCheckCollectionObjects(expectedData, mongoDb, collectionName);
+        }
+    }
+
+    /**
+     * Checks that all the expected collection names are present in MongoDB. Does not check that all the collection
+     * names present in Mongo are in the expected dataset collection names.
+     * <p/>
+     * If any expected collection isn't found in the database collection, the returned error indicates only the
+     * missing expected collections.
+     *
+     * @param expectedCollectionNames Expected collection names.
+     * @param mongodbCollectionNames  Current MongoDB collection names.
+     */
+    private static void flexibleCheckCollectionsName(Set<String> expectedCollectionNames, Set<String> mongodbCollectionNames) {
+        Set<String> mongoDbUserCollectionNames = getUserCollections(mongodbCollectionNames);
+
+        boolean ok = true;
+        HashSet<String> notFoundCollectionNames = new HashSet<String>();
+        for (String expectedCollectionName : expectedCollectionNames) {
+            if (!mongoDbUserCollectionNames.contains(expectedCollectionName)) {
+                ok = false;
+                notFoundCollectionNames.add(expectedCollectionName);
+            }
+        }
+
+        if (!ok) {
+            throw FailureHandler.createFailure("The following collection names %s were not found in the inserted collection names", notFoundCollectionNames);
+        }
+    }
+
+    /**
+     * Checks that each expected object in the collection exists in the database.
+     *
+     * @param expectedData   Expected data.
+     * @param mongoDb        Mongo database.
+     * @param collectionName Collection name.
+     */
+    private static void flexibleCheckCollectionObjects(DBObject expectedData, DB mongoDb, String collectionName) throws Error {
+        DBObject object = (DBObject) expectedData.get(collectionName);
+        BasicDBList dataObjects;
+
+        if (isShardOrIndexCollection(object)) {
+            dataObjects = (BasicDBList) object.get(DATA);
+        } else {
+            dataObjects = (BasicDBList) object;
+        }
+
+        DBCollection dbCollection = mongoDb.getCollection(collectionName);
+
+        for (Object dataObject : dataObjects) {
+            BasicDBObject expectedDataObject = (BasicDBObject) dataObject;
+            DBObject filteredExpectedDataObject = filterProperties(expectedDataObject);
+            DBObject foundObject = dbCollection.findOne(filteredExpectedDataObject);
+
+            if (dbCollection.count(filteredExpectedDataObject) > 1) {
+                logger.warn(String.format("There were found %d possible matches for this object # %s #. That could have been caused by ignoring too many properties.", dbCollection.count(filteredExpectedDataObject), expectedDataObject.toString()));
+            }
+
+            if (!exists(foundObject)) {
+                throw FailureHandler.createFailure("Object # %s # is not found into collection %s", filteredExpectedDataObject.toString(), collectionName);
+            }
+
+            // Check same keys without filtering
+            flexibleCheckSameKeys((DBObject) dataObject, foundObject);
+
+        }
+    }
+
+    /**
+     * Removes the properties set with "@IgnorePropertyValue" value from the dataObject.
+     *
+     * @param dataObject Object to filter.
+     * @return Data object without the properties to be ignored.
+     */
+    private static BasicDBObject filterProperties(BasicDBObject dataObject) {
+        BasicDBObject filteredDataObject = new BasicDBObject();
+
+        for (Map.Entry<String, Object> entry : dataObject.entrySet()) {
+            if (!(entry.getValue() instanceof String
+                    && entry.getValue().equals("@IgnorePropertyValue"))) {
+                filteredDataObject.put(entry.getKey(), entry.getValue());
+            }
+        }
+
+        return filteredDataObject;
+    }
+
+    /**
+     * Checks that all the properties are present in both expected and database objects, even the ignored properties.
+     * <p/>
+     * When there are differences between both objects keys, the returned error indicates only the keys that
+     * are missing in each object.
+     *
+     * @param expectedDataObject Expected object.
+     * @param foundObject        Database object.
+     */
+    private static void flexibleCheckSameKeys(DBObject expectedDataObject, DBObject foundObject) {
+        Set<String> expectedKeys = expectedDataObject.keySet();
+        Set<String> expectedNoneSystemKeys = noneSystemKeys(expectedKeys);
+        Set<String> foundKeys = foundObject.keySet();
+        Set<String> foundNoneSystemKeys = noneSystemKeys(foundKeys);
+
+        Set<String> allKeys = new HashSet<String>(expectedNoneSystemKeys);
+        allKeys.addAll(foundNoneSystemKeys);
+
+        HashSet<String> expectedKeysNotInserted = new HashSet<String>();
+        HashSet<String> insertedKeysNotExpected = new HashSet<String>();
+
+        for (String key : allKeys) {
+            if (!expectedNoneSystemKeys.contains(key)) {
+                insertedKeysNotExpected.add(key);
+            }
+            if (!foundNoneSystemKeys.contains(key)) {
+                expectedKeysNotInserted.add(key);
+            }
+        }
+
+        if (expectedKeysNotInserted.size() > 0 || insertedKeysNotExpected.size() > 0) {
+            StringBuilder errorMessage = new StringBuilder("Expected DbObject and insert DbObject have different keys: ");
+            if (expectedKeysNotInserted.size() > 0) {
+                errorMessage.append("expected keys not inserted ").append(expectedKeysNotInserted).append(" ");
+            }
+            if (insertedKeysNotExpected.size() > 0) {
+                errorMessage.append("inserted keys not expected ").append(insertedKeysNotExpected).append(" ");
+            }
+
+            throw FailureHandler.createFailure(errorMessage.toString());
+        }
+    }
+    //</editor-fold desc="Flexible comparator">
 }

--- a/nosqlunit-mongodb/src/main/java/com/lordofthejars/nosqlunit/mongodb/MongoFlexibleComparisonStrategy.java
+++ b/nosqlunit-mongodb/src/main/java/com/lordofthejars/nosqlunit/mongodb/MongoFlexibleComparisonStrategy.java
@@ -1,0 +1,54 @@
+package com.lordofthejars.nosqlunit.mongodb;
+
+import com.lordofthejars.nosqlunit.core.IOUtils;
+import com.mongodb.DBObject;
+import com.mongodb.util.JSON;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Comparison strategy that checks that all the expected data exists in the Mongo database.
+ * It doesn't compare that all the data stored in the database is included in the expected
+ * file, so other data not defined in the expected resource could exist in Mongo. It just
+ * assure that the expected data exists.
+ * <p/>
+ * Checks the following assertions:
+ * <li>
+ * <ul>
+ * Checks that all the expected collections are present in Mongo DB, but accepts other
+ * collections stored in the database that are not defined in the expected file.
+ * </ul>
+ * <ul>
+ * Checks that all the expected objects are present in Mongo DB, but accepts other
+ * objects stored in the same collections that are not defined as expected.
+ * </ul>
+ * <ul>
+ * For each object checks that all properties set with "@IgnorePropertyValue" value
+ * exist in the object stored in the database, but it accepts any saved value.
+ * </ul>
+ * </li>
+ *
+ * @author <a mailto="victor.hernandezbermejo@gmail.com">Víctor Hernández</a>
+ */
+public class MongoFlexibleComparisonStrategy implements MongoComparisonStrategy {
+
+    @Override
+    public boolean compare(MongoDbConnectionCallback connection, InputStream dataset) throws IOException {
+        String expectedJsonData = loadContentFromInputStream(dataset);
+        DBObject parsedData = parseData(expectedJsonData);
+
+        MongoDbAssertion.flexibleAssertEquals(parsedData, connection.db());
+
+        return true;
+    }
+
+    private String loadContentFromInputStream(InputStream inputStreamContent) throws IOException {
+        return IOUtils.readFullStream(inputStreamContent);
+    }
+
+    private DBObject parseData(String jsonData) throws IOException {
+        DBObject parsedData = (DBObject) JSON.parse(jsonData);
+        return parsedData;
+    }
+}

--- a/nosqlunit-mongodb/src/test/java/com/lordofthejars/nosqlunit/mongodb/MongoFlexibleComparisonStrategyTest.java
+++ b/nosqlunit-mongodb/src/test/java/com/lordofthejars/nosqlunit/mongodb/MongoFlexibleComparisonStrategyTest.java
@@ -1,0 +1,27 @@
+package com.lordofthejars.nosqlunit.mongodb;
+
+import com.lordofthejars.nosqlunit.annotation.CustomComparisonStrategy;
+import com.lordofthejars.nosqlunit.annotation.ShouldMatchDataSet;
+import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb.InMemoryMongoRuleBuilder.newInMemoryMongoDbRule;
+import static com.lordofthejars.nosqlunit.mongodb.MongoDbRule.MongoDbRuleBuilder.newMongoDbRule;
+
+@CustomComparisonStrategy(comparisonStrategy = MongoFlexibleComparisonStrategy.class)
+public class MongoFlexibleComparisonStrategyTest {
+
+    @ClassRule
+    public static final InMemoryMongoDb IN_MEMORY_MONGO_DB = newInMemoryMongoDbRule().build();
+
+    @Rule
+    public MongoDbRule mongoDbRule = newMongoDbRule().defaultManagedMongoDb("test");
+
+    @Test
+    @UsingDataSet(locations = "MongoFlexibleComparisonStrategyTest#thatShowWarnings.json")
+    @ShouldMatchDataSet(location = "MongoFlexibleComparisonStrategyTest#thatShowWarnings-expected.json")
+    public void thatShowsWarnings() {
+    }
+}

--- a/nosqlunit-mongodb/src/test/resources/com/lordofthejars/nosqlunit/mongodb/MongoFlexibleComparisonStrategyTest#thatShowWarnings-expected.json
+++ b/nosqlunit-mongodb/src/test/resources/com/lordofthejars/nosqlunit/mongodb/MongoFlexibleComparisonStrategyTest#thatShowWarnings-expected.json
@@ -1,0 +1,9 @@
+{
+  "collection": [
+    {
+      "1": "one",
+      "2": "@IgnorePropertyValue",
+      "3": "@IgnorePropertyValue"
+    }
+  ]
+}

--- a/nosqlunit-mongodb/src/test/resources/com/lordofthejars/nosqlunit/mongodb/MongoFlexibleComparisonStrategyTest#thatShowWarnings.json
+++ b/nosqlunit-mongodb/src/test/resources/com/lordofthejars/nosqlunit/mongodb/MongoFlexibleComparisonStrategyTest#thatShowWarnings.json
@@ -1,0 +1,29 @@
+{
+  "collection": [
+    {
+      "1": "one",
+      "2": "two",
+      "3": "three"
+    },
+    {
+      "1": "one",
+      "2": "2",
+      "3": "three"
+    },
+    {
+      "1": "one",
+      "2": "two",
+      "3": "3"
+    },
+    {
+      "1": "one",
+      "2": "2",
+      "3": "3"
+    }
+  ],
+  "another-collection": [
+    {
+      "value": "Some objects"
+    }
+  ]
+}


### PR DESCRIPTION
Comparison strategy that checks that all the expected data exists in the Mongo database. It doesn't compare that all the data stored in the database is included in the expected file, so other data not defined in the expected resource could exist in Mongo. It just assures that the expected data exists.

Checks the following assertions:
* Checks that all the expected collections are present in Mongo DB, but accepts other collections stored in the database that are not defined in the expected file.
* Checks that all the expected objects are present in Mongo DB, but accepts other objects stored in the same collections that are not defined as expected.
* For each object checks that all properties set with *@IgnorePropertyValue* value exist in the object stored in the database, but it accepts any saved value.