### PR TITLE
Implemented flexible comparison strategy using @IgnorePropertyValue(properties = {String...}) annotation for MongoDB

### DIFF
--- a/nosqlunit-core/src/main/java/com/lordofthejars/nosqlunit/annotation/IgnorePropertyValue.java
+++ b/nosqlunit-core/src/main/java/com/lordofthejars/nosqlunit/annotation/IgnorePropertyValue.java
@@ -1,0 +1,16 @@
+package com.lordofthejars.nosqlunit.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author <a mailto="victor.hernandezbermejo@gmail.com">Víctor Hernández</a>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface IgnorePropertyValue {
+
+    String[] properties() default {};
+}

--- a/nosqlunit-core/src/main/java/com/lordofthejars/nosqlunit/annotation/IgnorePropertyValue.java
+++ b/nosqlunit-core/src/main/java/com/lordofthejars/nosqlunit/annotation/IgnorePropertyValue.java
@@ -6,6 +6,26 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
+ * Allow the user define the properties that should be ignored when checking
+ * the expected objects.
+ *
+ * Accepts two formats for property definition:
+ * <li>
+ *     <ol>
+ *         collection.property : When is defined both collection name and property
+ *         name, the exclusion only will affect to the indicated collection.
+ *         e.g: With @IgnorePropertyValue(properties = {"book.date"}), the property
+ *         will be ignored in each object of the other collection. If other objects
+ *         have the property 'date' it won't be ignored.
+ *     </ol>
+ *     <ol>
+ *         property : When only is defined the property name, it will be excluded
+ *         for all objects in any expected collection.
+ *         e.g: With @IgnorePropertyValue(properties = {"date"}), the property 'date'
+ *         will be ignored in each object, no matter the collection.
+ *     </ol>
+ * </li>
+ *
  * @author <a mailto="victor.hernandezbermejo@gmail.com">Víctor Hernández</a>
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/nosqlunit-core/src/main/java/com/lordofthejars/nosqlunit/core/FlexibleComparisonStrategy.java
+++ b/nosqlunit-core/src/main/java/com/lordofthejars/nosqlunit/core/FlexibleComparisonStrategy.java
@@ -1,0 +1,9 @@
+package com.lordofthejars.nosqlunit.core;
+
+/**
+ * @author <a mailto="victor.hernandezbermejo@gmail.com">Víctor Hernández</a>
+ */
+public interface FlexibleComparisonStrategy {
+
+    void setIgnorePropertyValues(String... propertiesToIgnore);
+}

--- a/nosqlunit-mongodb/src/main/java/com/lordofthejars/nosqlunit/mongodb/MongoDbAssertion.java
+++ b/nosqlunit-mongodb/src/main/java/com/lordofthejars/nosqlunit/mongodb/MongoDbAssertion.java
@@ -294,8 +294,7 @@ public class MongoDbAssertion {
     }
 
     /**
-     * Removes the properties set with "@IgnorePropertyValue" value from the dataObject
-     * or defined in propertiesToIgnore annotation.
+     * Removes the properties defined with @IgnorePropertyValue annotation.
      *
      * @param dataObject Object to filter.
      * @param propertiesToIgnore Properties to filter
@@ -305,8 +304,7 @@ public class MongoDbAssertion {
         BasicDBObject filteredDataObject = new BasicDBObject();
 
         for (Map.Entry<String, Object> entry : dataObject.entrySet()) {
-            if (!((propertiesToIgnore != null && propertiesToIgnore.contains(entry.getKey()))
-                    || (entry.getValue() instanceof String && entry.getValue().equals("@IgnorePropertyValue")))) {
+            if (propertiesToIgnore == null || !propertiesToIgnore.contains(entry.getKey())) {
                 filteredDataObject.put(entry.getKey(), entry.getValue());
             }
         }

--- a/nosqlunit-mongodb/src/main/java/com/lordofthejars/nosqlunit/mongodb/MongoFlexibleComparisonStrategy.java
+++ b/nosqlunit-mongodb/src/main/java/com/lordofthejars/nosqlunit/mongodb/MongoFlexibleComparisonStrategy.java
@@ -1,5 +1,6 @@
 package com.lordofthejars.nosqlunit.mongodb;
 
+import com.lordofthejars.nosqlunit.core.FlexibleComparisonStrategy;
 import com.lordofthejars.nosqlunit.core.IOUtils;
 import com.mongodb.DBObject;
 import com.mongodb.util.JSON;
@@ -31,14 +32,17 @@ import java.io.InputStream;
  *
  * @author <a mailto="victor.hernandezbermejo@gmail.com">Víctor Hernández</a>
  */
-public class MongoFlexibleComparisonStrategy implements MongoComparisonStrategy {
+public class MongoFlexibleComparisonStrategy
+        implements MongoComparisonStrategy, FlexibleComparisonStrategy {
+
+    private String[] ignorePropertyValues = new String[0];
 
     @Override
     public boolean compare(MongoDbConnectionCallback connection, InputStream dataset) throws IOException {
         String expectedJsonData = loadContentFromInputStream(dataset);
         DBObject parsedData = parseData(expectedJsonData);
 
-        MongoDbAssertion.flexibleAssertEquals(parsedData, connection.db());
+        MongoDbAssertion.flexibleAssertEquals(parsedData, ignorePropertyValues, connection.db());
 
         return true;
     }
@@ -50,5 +54,10 @@ public class MongoFlexibleComparisonStrategy implements MongoComparisonStrategy 
     private DBObject parseData(String jsonData) throws IOException {
         DBObject parsedData = (DBObject) JSON.parse(jsonData);
         return parsedData;
+    }
+
+    @Override
+    public void setIgnorePropertyValues(String... ignorePropertyValues) {
+        this.ignorePropertyValues = ignorePropertyValues;
     }
 }

--- a/nosqlunit-mongodb/src/main/java/com/lordofthejars/nosqlunit/mongodb/MongoFlexibleComparisonStrategy.java
+++ b/nosqlunit-mongodb/src/main/java/com/lordofthejars/nosqlunit/mongodb/MongoFlexibleComparisonStrategy.java
@@ -37,15 +37,15 @@ import java.io.InputStream;
  * It accepts two formats for property definition:
  * <li>
  *     <ol>
- *         collection.property : When is defined both collection and property name
+ *         collection.property : When are defined both collection and property name
  *         the exclusion will only affect to the indicated collection.
- *         e.g: With @IgnorePropertyValue(properties = {"book.date"}), the property
- *         will be ignored in each object of the other collection. If other objects
- *         have the property 'date' it won't be ignored.
+ *         e.g: With @IgnorePropertyValue(properties = {"book.date"}), the property date
+ *         will be ignored in each object of the 'book' collection. If other objects in
+ *         different collections have the property 'date' it won't be ignored.
  *     </ol>
  *     <ol>
- *         property : When only is defined the property name, it will be excluded
- *         for all objects in any expected collection.
+ *         property : When only is defined the property name it will be excluded
+ *         from all objects in any expected collection.
  *         e.g: With @IgnorePropertyValue(properties = {"date"}), the property 'date'
  *         will be ignored in each object, no matter the collection.
  *     </ol>
@@ -55,6 +55,9 @@ import java.io.InputStream;
  * collection and property names defined in
  * <a href="http://docs.mongodb.org/manual/reference/limits/#naming-restrictions>
  * "Mongo DB: naming restrictions"</a> document.
+ *
+ * When more than one object stored in the database matches the expected object after
+ * ignoring properties a warning is shown notifying the number of objects that were found.
  *
  * @author <a mailto="victor.hernandezbermejo@gmail.com">Víctor Hernández</a>
  */

--- a/nosqlunit-mongodb/src/main/java/com/lordofthejars/nosqlunit/mongodb/MongoFlexibleComparisonStrategy.java
+++ b/nosqlunit-mongodb/src/main/java/com/lordofthejars/nosqlunit/mongodb/MongoFlexibleComparisonStrategy.java
@@ -16,19 +16,45 @@ import java.io.InputStream;
  * <p/>
  * Checks the following assertions:
  * <li>
- * <ul>
- * Checks that all the expected collections are present in Mongo DB, but accepts other
- * collections stored in the database that are not defined in the expected file.
- * </ul>
- * <ul>
- * Checks that all the expected objects are present in Mongo DB, but accepts other
- * objects stored in the same collections that are not defined as expected.
- * </ul>
- * <ul>
- * For each object checks that all properties set with "@IgnorePropertyValue" value
- * exist in the object stored in the database, but it accepts any saved value.
- * </ul>
+ *      <ul>
+ *          Checks that all the expected collections are present in Mongo DB, but accepts
+ *          other collections stored in the database that are not defined in the expected
+ *          file.
+ *      </ul>
+ *      <ul>
+ *          Checks that all the expected objects are present in Mongo DB, but accepts
+ *          other objects stored in the same collections that are not defined as expected.
+ *      </ul>
+ *      <ul>
+ *          For each object checks that all properties set to be ignored its value
+ *          exist in the object stored in the database, but it accepts any saved value.
+ *      </ul>
  * </li>
+ *
+ * The annotation '@IgnorePropertyValue(properties = {String...})' allows the user define
+ * the properties that should be ignored when checking the expected objects.
+ *
+ * It accepts two formats for property definition:
+ * <li>
+ *     <ol>
+ *         collection.property : When is defined both collection and property name
+ *         the exclusion will only affect to the indicated collection.
+ *         e.g: With @IgnorePropertyValue(properties = {"book.date"}), the property
+ *         will be ignored in each object of the other collection. If other objects
+ *         have the property 'date' it won't be ignored.
+ *     </ol>
+ *     <ol>
+ *         property : When only is defined the property name, it will be excluded
+ *         for all objects in any expected collection.
+ *         e.g: With @IgnorePropertyValue(properties = {"date"}), the property 'date'
+ *         will be ignored in each object, no matter the collection.
+ *     </ol>
+ * </li>
+ *
+ * The values of the properties to be ignored should be named following the rules for valid
+ * collection and property names defined in
+ * <a href="http://docs.mongodb.org/manual/reference/limits/#naming-restrictions>
+ * "Mongo DB: naming restrictions"</a> document.
  *
  * @author <a mailto="victor.hernandezbermejo@gmail.com">Víctor Hernández</a>
  */

--- a/nosqlunit-mongodb/src/test/java/com/lordofthejars/nosqlunit/mongodb/MongoFlexibleComparisonStrategyTest.java
+++ b/nosqlunit-mongodb/src/test/java/com/lordofthejars/nosqlunit/mongodb/MongoFlexibleComparisonStrategyTest.java
@@ -1,6 +1,7 @@
 package com.lordofthejars.nosqlunit.mongodb;
 
 import com.lordofthejars.nosqlunit.annotation.CustomComparisonStrategy;
+import com.lordofthejars.nosqlunit.annotation.IgnorePropertyValue;
 import com.lordofthejars.nosqlunit.annotation.ShouldMatchDataSet;
 import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
 import org.junit.ClassRule;
@@ -22,6 +23,7 @@ public class MongoFlexibleComparisonStrategyTest {
     @Test
     @UsingDataSet(locations = "MongoFlexibleComparisonStrategyTest#thatShowWarnings.json")
     @ShouldMatchDataSet(location = "MongoFlexibleComparisonStrategyTest#thatShowWarnings-expected.json")
+    @IgnorePropertyValue(properties = {"2", "collection.3"})
     public void thatShowsWarnings() {
     }
 }

--- a/nosqlunit-mongodb/src/test/resources/com/lordofthejars/nosqlunit/mongodb/MongoFlexibleComparisonStrategyTest#thatShowWarnings-expected.json
+++ b/nosqlunit-mongodb/src/test/resources/com/lordofthejars/nosqlunit/mongodb/MongoFlexibleComparisonStrategyTest#thatShowWarnings-expected.json
@@ -2,7 +2,7 @@
   "collection": [
     {
       "1": "one",
-      "2": "@IgnorePropertyValue",
+      "2": "two",
       "3": "@IgnorePropertyValue"
     }
   ]

--- a/nosqlunit-mongodb/src/test/resources/com/lordofthejars/nosqlunit/mongodb/MongoFlexibleComparisonStrategyTest#thatShowWarnings-expected.json
+++ b/nosqlunit-mongodb/src/test/resources/com/lordofthejars/nosqlunit/mongodb/MongoFlexibleComparisonStrategyTest#thatShowWarnings-expected.json
@@ -3,7 +3,7 @@
     {
       "1": "one",
       "2": "two",
-      "3": "@IgnorePropertyValue"
+      "3": "three"
     }
   ]
 }


### PR DESCRIPTION
Comparison strategy that checks that all the expected data exists in the Mongo database. It doesn't compare that all the data stored in the database is included in the expected file, so other data not defined in the expected resource could exist in Mongo. It just assure that the expected data exists.

Checks the following assertions:
* Checks that all the expected collections are present in Mongo DB, but accepts other collections stored in the database that are not defined in the expected file.
* Checks that all the expected objects are present in Mongo DB, but accepts other objects stored in the same collections that are not defined as expected.
* For each object checks that all properties set to be ignored its value exist in the object stored in the database, but it accepts any saved value.

The annotation **@IgnorePropertyValue(properties = {String...})** allows the user define the properties that should be ignored when checking the expected objects.

It accepts two formats for property definition:

1. **collection.property** : When are defined both collection and property name the exclusion will only affect to the indicated collection.
  * e.g: With *@IgnorePropertyValue(properties = {"book.date"})*, the property date *will* be ignored in each object of the *book* collection. If other objects in different collections have the property *date* it won't be ignored.
1. **property** : When only is defined the property name it will be excluded from all objects in any expected collection.
  * e.g: With *@IgnorePropertyValue(properties = {"date"})*, the property *date* will be ignored in each object, no matter the collection.

The values of the properties to be ignored should be named following the rules for valid collection and property names defined in [Mongo DB: naming restrictions](http://docs.mongodb.org/manual/reference/limits/#naming-restrictions) document.

When more than one object stored in the database matches the expected object after ignoring properties a warning is shown notifying the number of objects that were found.