### PR TITLE
Adding connectionIdentifier helper to remote ES config builder.

### DIFF
--- a/nosqlunit-elasticsearch/src/main/java/com/lordofthejars/nosqlunit/elasticsearch/RemoteElasticsearchConfigurationBuilder.java
+++ b/nosqlunit-elasticsearch/src/main/java/com/lordofthejars/nosqlunit/elasticsearch/RemoteElasticsearchConfigurationBuilder.java
@@ -30,6 +30,11 @@ private ElasticsearchConfiguration elasticsearchConfiguration = new Elasticsearc
 		this.elasticsearchConfiguration.setSettings(settings);
 		return this;
 	}
+
+	public RemoteElasticsearchConfigurationBuilder connectionIdentifier(String connectionIdentifier) {
+        this.elasticsearchConfiguration.setConnectionIdentifier(connectionIdentifier);
+        return this;
+    }
 	
 	public ElasticsearchConfiguration build() {
 		


### PR DESCRIPTION
Fixes lordofthejars/nosql-unit#137