### PR TITLE
Adding connectionIdentifier helper to managed ES config builder.

### DIFF
--- a/nosqlunit-elasticsearch/src/main/java/com/lordofthejars/nosqlunit/elasticsearch/ManagedElasticsearchConfigurationBuilder.java
+++ b/nosqlunit-elasticsearch/src/main/java/com/lordofthejars/nosqlunit/elasticsearch/ManagedElasticsearchConfigurationBuilder.java
@@ -27,6 +27,11 @@ public class ManagedElasticsearchConfigurationBuilder {
 		this.elasticsearchConfiguration.setSettings(settings);
 		return this;
 	}
+
+	public ManagedElasticsearchConfigurationBuilder connectionIdentifier(String connectionIdentifier) {
+		this.elasticsearchConfiguration.setConnectionIdentifier(connectionIdentifier);
+		return this;
+	}
 	
 	public ElasticsearchConfiguration build() {
 		


### PR DESCRIPTION
Just noticed that this helper method is also missing for the managed ES config builder. I am not using it, but I just added it for the sake of completeness.