### PR TITLE
spring mongo - support multiple application contexts

### DIFF
--- a/nosqlunit-mongodb/pom.xml
+++ b/nosqlunit-mongodb/pom.xml
@@ -9,7 +9,7 @@
 	<artifactId>nosqlunit-mongodb</artifactId>
 
 	<properties>
-		<spring.data.mongodb.version>1.1.1.RELEASE</spring.data.mongodb.version>
+		<spring.data.mongodb.version>1.4.3.RELEASE</spring.data.mongodb.version>
 	</properties>
 
 	<dependencies>
@@ -37,7 +37,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-test</artifactId>
-			<version>3.1.2.RELEASE</version>
+			<version>3.2.9.RELEASE</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/nosqlunit-mongodb/src/main/java/com/lordofthejars/nosqlunit/mongodb/SpringMongoDbRule.java
+++ b/nosqlunit-mongodb/src/main/java/com/lordofthejars/nosqlunit/mongodb/SpringMongoDbRule.java
@@ -3,8 +3,7 @@ package com.lordofthejars.nosqlunit.mongodb;
 import static ch.lambdaj.collection.LambdaCollections.with;
 import static org.hamcrest.CoreMatchers.anything;
 
-import java.util.Map;
-
+import com.lordofthejars.nosqlunit.util.SpringUtils;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;
 import org.springframework.context.ApplicationContext;
@@ -34,25 +33,17 @@ public class SpringMongoDbRule extends MongoDbRule {
 		return super.apply(base, method, testObject);
 	}
 	
-	private Mongo definedMongo(Object testObject) {
+	private Mongo definedMongo(Object testObject)
+	{
 		ApplicationContext applicationContext = propertyGetter.propertyByType(testObject, ApplicationContext.class);
 
-		Map<String, Mongo> beansOfType = applicationContext.getBeansOfType(Mongo.class);
-		
-		if(beansOfType == null) {
-			throw new IllegalArgumentException(
-					"At least one Mongo instance should be defined into Spring Application Context.");
-		}
-		
-		Mongo mongo = with(beansOfType).values().first(anything());
+		Mongo mongo = SpringUtils.getBeanOfType(applicationContext, Mongo.class);
 
 		if (mongo == null) {
 			throw new IllegalArgumentException(
 					"At least one Mongo instance should be defined into Spring Application Context.");
 		}
-
 		return mongo;
-
 	}
-	
+
 }

--- a/nosqlunit-mongodb/src/main/java/com/lordofthejars/nosqlunit/util/SpringUtils.java
+++ b/nosqlunit-mongodb/src/main/java/com/lordofthejars/nosqlunit/util/SpringUtils.java
@@ -1,0 +1,34 @@
+package com.lordofthejars.nosqlunit.util;
+import org.springframework.context.ApplicationContext;
+
+import java.util.Map;
+
+import static ch.lambdaj.collection.LambdaCollections.with;
+import static org.hamcrest.CoreMatchers.anything;
+
+
+public class SpringUtils
+{
+	/**
+	 * Search recursively in current and parent applicationContext's for Bean of Type T
+	 * @param applicationContext Spring application context to start searching from
+	 * @param aClass Class type of bean to search
+	 * @param <T> Type of bean to search
+	 * @return first matched bean found
+	 */
+	public static <T> T getBeanOfType(ApplicationContext applicationContext, Class<T> aClass)
+	{
+		Map<String, T> beansOfType;
+		do
+		{
+			beansOfType = applicationContext.getBeansOfType(aClass);
+			if (beansOfType != null && beansOfType.size() > 0)
+			{
+				return with(beansOfType).values().first(anything());
+			}
+			applicationContext = applicationContext.getParent();
+		}
+		while (applicationContext != null);
+		return null;
+	}
+}

--- a/nosqlunit-mongodb/src/test/java/com/lordofthejars/nosqlunit/mongodb/integration/SpringEmbeddedInstanceBase.java
+++ b/nosqlunit-mongodb/src/test/java/com/lordofthejars/nosqlunit/mongodb/integration/SpringEmbeddedInstanceBase.java
@@ -1,0 +1,34 @@
+package com.lordofthejars.nosqlunit.mongodb.integration;
+
+import com.lordofthejars.nosqlunit.core.DatabaseOperation;
+import com.lordofthejars.nosqlunit.mongodb.MongoDbRule;
+import com.mongodb.Mongo;
+import org.junit.Rule;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+
+import static com.lordofthejars.nosqlunit.mongodb.MongoDbRule.MongoDbRuleBuilder.newMongoDbRule;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+
+public abstract class SpringEmbeddedInstanceBase
+{
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Autowired
+    private Mongo mongo;
+
+    @Rule
+    public MongoDbRule mongoDbRule = newMongoDbRule().defaultSpringMongoDb("test");
+
+    protected void validateMongoConnection()
+    {
+        DatabaseOperation<Mongo> databaseOperation = mongoDbRule.getDatabaseOperation();
+        Mongo connectionManager = databaseOperation.connectionManager();
+
+        assertThat(connectionManager, is(mongo));
+    }
+
+}

--- a/nosqlunit-mongodb/src/test/java/com/lordofthejars/nosqlunit/mongodb/integration/WhenSpringEmbeddedInstanceIsRequired.java
+++ b/nosqlunit-mongodb/src/test/java/com/lordofthejars/nosqlunit/mongodb/integration/WhenSpringEmbeddedInstanceIsRequired.java
@@ -1,42 +1,17 @@
 package com.lordofthejars.nosqlunit.mongodb.integration;
 
-import static com.lordofthejars.nosqlunit.mongodb.MongoDbRule.MongoDbRuleBuilder.newMongoDbRule;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import com.lordofthejars.nosqlunit.core.DatabaseOperation;
-import com.lordofthejars.nosqlunit.mongodb.MongoDbRule;
-import com.mongodb.Mongo;
-
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations="embedded-mongo-spring-definition.xml")
-public class WhenSpringEmbeddedInstanceIsRequired {
+public class WhenSpringEmbeddedInstanceIsRequired extends SpringEmbeddedInstanceBase{
 
-	@Autowired
-	private ApplicationContext applicationContext;
-	
-	@Autowired
-	private Mongo mongo;
-	
-	@Rule
-	public MongoDbRule mongoDbRule = newMongoDbRule().defaultSpringMongoDb("test");
-	
 	@Test
 	public void connection_manager_should_be_the_one_defined_in_application_context() {
-		
-		DatabaseOperation<Mongo> databaseOperation = mongoDbRule.getDatabaseOperation();
-		Mongo connectionManager = databaseOperation.connectionManager();
-		
-		assertThat(connectionManager, is(mongo));
-		
+		validateMongoConnection();
 	}
-	
+
 }

--- a/nosqlunit-mongodb/src/test/java/com/lordofthejars/nosqlunit/mongodb/integration/WhenSpringEmbeddedInstanceIsRequiredWithMultiAppCtxt.java
+++ b/nosqlunit-mongodb/src/test/java/com/lordofthejars/nosqlunit/mongodb/integration/WhenSpringEmbeddedInstanceIsRequiredWithMultiAppCtxt.java
@@ -1,0 +1,30 @@
+package com.lordofthejars.nosqlunit.mongodb.integration;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextHierarchy({
+        @ContextConfiguration("embedded-mongo-spring-definition.xml"),
+        @ContextConfiguration(classes=WhenSpringEmbeddedInstanceIsRequiredWithMultiAppCtxt.MyTestDependency.class)
+})
+public class WhenSpringEmbeddedInstanceIsRequiredWithMultiAppCtxt extends SpringEmbeddedInstanceBase{
+
+	@Autowired
+	MyTestDependency myTestDependency;
+
+	@Test
+	public void connection_manager_should_be_the_one_defined_in_application_context() {
+		validateMongoConnection();
+		Assert.assertNotNull(myTestDependency);
+	}
+	@Component
+	public static class MyTestDependency{}
+
+}


### PR DESCRIPTION
SpringMongoDbRule locates Mongo bean in parent application context if not found in child