### PR TITLE
Add support for Elasticsearch 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -2894,34 +2894,34 @@ public class WhenUserIsInserted {
 
 	@ClassRule
 	public static final ManagedInfinispan MANAGED_INFINISPAN = newManagedInfinispanRule().infinispanPath("/opt/infinispan-5.1.6").build();
-	
+
 	@Rule
 	public final InfinispanRule infinispanRule = newInfinispanRule().defaultManagedInfinispan();
-	
+
 	@Inject
 	private BasicCache<String, User> remoteCache;
-	
+
 	@UsingDataSet(loadStrategy=LoadStrategyEnum.DELETE_ALL)
 	@ShouldMatchDataSet(location="user.json")
 	@Test
 	public void user_should_be_available_in_cache() {
-		
+
 		UserManager userManager = new UserManager(remoteCache);
 		userManager.addUser(new User("alex", 32));
 	}
-	
+
 }
 ~~~~
 
 Elasticsearch Engine
-==============
+====================
+
+Elasticsearch is a distributed, RESTful, free/open source search server based on Apache Lucene.
 
 Elasticsearch
 =============
 
-ElasticSearch is a distributed, RESTful, free/open source search server based on Apache Lucene.
-
-**NoSQLUnit** supports **Elasticsearch** by using next classes:
+**NoSQLUnit** supports **Elasticsearch 1.x** by using next classes:
 
   ----------- -----------------------------------------------------
   In Memory   com.lordofthejars.nosqlunit.elasticsearch.EmbeddedElasticsearch
@@ -2936,10 +2936,26 @@ ElasticSearch is a distributed, RESTful, free/open source search server based on
 
   : Manager Rule
 
+
+**NoSQLUnit** supports **Elasticsearch 2.x** by using next classes:
+
+  ----------- -----------------------------------------------------
+  In Memory   com.lordofthejars.nosqlunit.elasticsearch2.EmbeddedElasticsearch
+  Managed     com.lordofthejars.nosqlunit.elasticsearch2.ManagedElasticsearch
+  ----------- -----------------------------------------------------
+
+  : Lifecycle Management Rules
+
+  ---------------------- -------------------------------------------------
+  NoSQLUnit Management   com.lordofthejars.nosqlunit.elasticsearch2.ElasticsearchRule
+  ---------------------- -------------------------------------------------
+
+  : Manager Rule
+
 Maven Setup
 -----------
 
-To use **NoSQLUnit** with **Elasticsearch** you only need to add next dependency:
+To use **NoSQLUnit** with **Elasticsearch 1.x** you only need to add next dependency:
 
 ~~~~ {.xml}
 <dependency>
@@ -2948,6 +2964,17 @@ To use **NoSQLUnit** with **Elasticsearch** you only need to add next dependency
     <version>${version.nosqlunit}</version>
 </dependency>
 ~~~~
+
+To use **NoSQLUnit** with **Elasticsearch 2.x** you only need to add next dependency:
+
+~~~~ {.xml}
+<dependency>
+    <groupId>com.lordofthejars</groupId>
+    <artifactId>nosqlunit-elasticsearch2</artifactId>
+    <version>${version.nosqlunit}</version>
+</dependency>
+~~~~
+
 
 Dataset Format
 --------------
@@ -2990,7 +3017,7 @@ Datasets must have next format:
 
 > Notice that if attributes value are integers, double quotes are not
   required. Also you can define as many *index* subdocuments as required, but only one *data* document which will be inserted into **Elasticsearch**.
-  Moreover property *indexId* is only mandatory if you want to use the inserted data to be validated with *@ShouldMatchDataSet*. Document index is used to run comparisions      faster than retrieving all data. If you are not planning to use the expectations capability of **NoSQLUnit** then you are not required to set *indexId* property and **Elasticsearch** will provie one for you.
+  Moreover property *indexId* is only mandatory if you want to use the inserted data to be validated with *@ShouldMatchDataSet*. Document index is used to run comparisions      faster than retrieving all data. If you are not planning to use the expectations capability of **NoSQLUnit** then you are not required to set *indexId* property and **Elasticsearch** will provide one for you.
 
 Getting Started
 ---------------
@@ -3004,8 +3031,8 @@ test, integration test, deployment test, ...) you will require an
 
 #### Embedded
 
-To configure **embedded** approach you should only instantiate next
-rule:
+To configure the **embedded** approach with **Elasticsearch 1.x**
+you should only instantiate the following rule:
 
 ~~~~ {.java}
 import static com.lordofthejars.nosqlunit.elasticsearch.EmbeddedElasticsearch.EmbeddedElasticsearchRuleBuilder.newEmbeddedElasticsearchRule;
@@ -3014,20 +3041,39 @@ import static com.lordofthejars.nosqlunit.elasticsearch.EmbeddedElasticsearch.Em
 public static final EmbeddedElasticsearch EMBEDDED_ELASTICSEARCH = newEmbeddedElasticsearchRule().build();
 ~~~~
 
-By default Elasticsearch Node is started with property *local* set to true, but this property and all other supported properties can be configured or you can still use the default configuration approach provided by **Elasticsearch** by creating `elasticsearch.yml` file into classpath. 
+In order to configure the **embedded** approach with **Elasticsearch 2.x**
+you should instantiate the following rule:
+
+~~~~ {.java}
+import static com.lordofthejars.nosqlunit.elasticsearch2.EmbeddedElasticsearch.EmbeddedElasticsearchRuleBuilder.newEmbeddedElasticsearchRule;
+
+@ClassRule
+public static final EmbeddedElasticsearch EMBEDDED_ELASTICSEARCH = newEmbeddedElasticsearchRule().build();
+~~~~
+
+By default, the **Elasticsearch** node is started as a client node (`node.local: true`), but this property and all other supported properties can be configured or you can still use the default configuration approach provided by **Elasticsearch** by creating `elasticsearch.yml` file into classpath.
 
 Data will be stored in `target/elasticsearch-test-data/impermanent-db` directory.
 
 #### Managed
 
-To configure the **managed** way, we should use ManagedElasticsearch rule and
+To configure the **managed** way with **Elasticsearch 1.x**, we should use the `ManagedElasticsearch` rule and
 may require some configuration parameters.
 
 ~~~~ {.java}
 import static com.lordofthejars.nosqlunit.elasticsearch.ManagedElasticsearch.ManagedElasticsearchRuleBuilder.newManagedElasticsearchRule;
 
 @ClassRule
-public static final ManagedElasticsearch MANAGED_ELASTICSEARCH = newManagedElasticsearchRule().elasticsearchPath("/opt/elasticsearch-0.20.5").build();
+public static final ManagedElasticsearch MANAGED_ELASTICSEARCH = newManagedElasticsearchRule().elasticsearchPath("/opt/elasticsearch-1.7.5").build();
+~~~~
+
+In order to use a **managed** instance with **Elasticsearch 2.x**, use the following rule:
+
+~~~~ {.java}
+import static com.lordofthejars.nosqlunit.elasticsearch2.ManagedElasticsearch.ManagedElasticsearchRuleBuilder.newManagedElasticsearchRule;
+
+@ClassRule
+public static final ManagedElasticsearch MANAGED_ELASTICSEARCH = newManagedElasticsearchRule().elasticsearchPath("/opt/elasticsearch-2.0.2").build();
 ~~~~
 
 By default managed *Elasticsearch* rule uses next default values:
@@ -3071,7 +3117,9 @@ import static com.lordofthejars.nosqlunit.elasticsearch.ElasticsearchRule.Elasti
 public ElasticsearchRule elasticsearchRule = newElasticsearchRule().defaultEmbeddedElasticsearch();
 ~~~~
 
-If you need to customize embedded connection we can use *EmbeddedElasticsearchConfigurationBuilder* class builder. 
+If you're using **Elasticsearch 2.x**, simply use the classes inside the package `com.lordofthejars.nosqlunit.elasticsearch2`.
+
+If you need to customize embedded connection we can use *EmbeddedElasticsearchConfigurationBuilder* class builder.
 
 #### Managed
 
@@ -3092,7 +3140,9 @@ import static com.lordofthejars.nosqlunit.elasticsearch.ElasticsearchRule.Elasti
 public ElasticsearchRule elasticsearchRule = newElasticsearchRule().defaultManagedElasticsearch();
 ~~~~
 
-But you can cusomize connection parameters by using *ManagedElasticsearchConfigurationBuilder* class. There you can set the *Settings* class and define the transport port. 
+If you're using **Elasticsearch 2.x**, simply use the classes inside the package `com.lordofthejars.nosqlunit.elasticsearch2`.
+
+But you can customize connection parameters by using *ManagedElasticsearchConfigurationBuilder* class. There you can set the *Settings* class and define the transport port.
 
 #### Remote
 
@@ -3135,23 +3185,23 @@ Managed test:
 
 ~~~~ {.java}
 @ClassRule
-public static final ManagedElasticsearch MANAGED_EALSTICSEARCH = newManagedElasticsearchRule().elasticsearchPath("/opt/elasticsearch-0.20.5").build();
-	
+public static final ManagedElasticsearch MANAGED_EALSTICSEARCH = newManagedElasticsearchRule().elasticsearchPath("/opt/elasticsearch-1.7.5").build();
+
 @Rule
 public ElasticsearchRule elasticsearchRule = newElasticsearchRule().defaultManagedElasticsearch();
-	
+
 @Inject
 private Client client;
-	
+
 @Test
 @UsingDataSet(locations="books.json", loadStrategy=LoadStrategyEnum.CLEAN_INSERT)
 public void all_books_should_be_returned() {
-		
+
 	BookManager bookManager = new BookManager(client);
 	List<Book> books = bookManager.searchAllBooks();
-		
+
 	assertThat(books, hasItems(new Book("The Hobbit", 293)));
-		
+
 }
 ~~~~
 

--- a/nosqlunit-elasticsearch2/pom.xml
+++ b/nosqlunit-elasticsearch2/pom.xml
@@ -1,0 +1,42 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.lordofthejars</groupId>
+		<artifactId>nosqlunit</artifactId>
+		<version>0.9.0</version>
+	</parent>
+	<artifactId>nosqlunit-elasticsearch2</artifactId>
+
+	<dependencies>
+		<dependency>
+			<artifactId>nosqlunit-core</artifactId>
+			<groupId>com.lordofthejars</groupId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.elasticsearch</groupId>
+			<artifactId>elasticsearch</artifactId>
+			<version>${elasticsearch2.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>2.4</version>
+				<configuration>
+					<source>1.7</source>
+					<target>1.7</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+	
+</project>

--- a/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/DefaultElasticsearchComparisonStrategy.java
+++ b/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/DefaultElasticsearchComparisonStrategy.java
@@ -1,0 +1,24 @@
+package com.lordofthejars.nosqlunit.elasticsearch2;
+
+import com.lordofthejars.nosqlunit.elasticsearch2.parser.DataReader;
+import com.lordofthejars.nosqlunit.core.NoSqlAssertionError;
+import org.elasticsearch.client.Client;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+
+public class DefaultElasticsearchComparisonStrategy implements ElasticsearchComparisonStrategy {
+	@Override
+	public boolean compare(ElasticsearchConnectionCallback connection, InputStream dataset) throws NoSqlAssertionError,
+			Throwable {
+		final Client nodeClient = connection.nodeClient();
+		final List<Map<String, Object>> documents = DataReader.getDocuments(dataset);
+		ElasticsearchAssertion.strictAssertEquals(documents, nodeClient);
+		return true;
+	}
+
+	@Override
+	public void setIgnoreProperties(String[] ignoreProperties) {
+	}
+}

--- a/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/DefaultElasticsearchInsertionStrategy.java
+++ b/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/DefaultElasticsearchInsertionStrategy.java
@@ -1,0 +1,13 @@
+package com.lordofthejars.nosqlunit.elasticsearch2;
+
+import com.lordofthejars.nosqlunit.elasticsearch2.parser.DataReader;
+
+import java.io.InputStream;
+
+public class DefaultElasticsearchInsertionStrategy implements ElasticsearchInsertionStrategy {
+	@Override
+	public void insert(ElasticsearchConnectionCallback connection, InputStream dataset) throws Throwable {
+		DataReader dataReader = new DataReader(connection.nodeClient());
+		dataReader.read(dataset);
+	}
+}

--- a/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/ElasticsearchAssertion.java
+++ b/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/ElasticsearchAssertion.java
@@ -1,0 +1,136 @@
+package com.lordofthejars.nosqlunit.elasticsearch2;
+
+import com.lordofthejars.nosqlunit.elasticsearch2.parser.DataReader;
+import com.lordofthejars.nosqlunit.core.FailureHandler;
+import com.lordofthejars.nosqlunit.util.DeepEquals;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.elasticsearch.action.count.CountResponse;
+import org.elasticsearch.action.get.GetRequestBuilder;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.client.Client;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ElasticsearchAssertion {
+	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+	private ElasticsearchAssertion() {
+		super();
+	}
+
+	public static void strictAssertEquals(List<Map<String, Object>> expectedDocuments, Client client) {
+
+		checkNumberOfDocuments(expectedDocuments, client);
+
+		for (Map<String, Object> document : expectedDocuments) {
+			final Object object = document.get(DataReader.DOCUMENT_ELEMENT);
+
+			if (object instanceof List) {
+				@SuppressWarnings("unchecked")
+				final List<Map<String, Object>> properties = (List<Map<String, Object>>) object;
+
+				final List<GetRequestBuilder> indexes = new ArrayList<>();
+				Map<String, Object> expectedDataOfDocument = new HashMap<>();
+
+				for (Map<String, Object> property : properties) {
+
+					if (property.containsKey(DataReader.INDEX_ELEMENT)) {
+						indexes.add(prepareGetIndex(property.get(DataReader.INDEX_ELEMENT), client));
+					} else {
+						if (property.containsKey(DataReader.DATA_ELEMENT)) {
+							expectedDataOfDocument = dataOfDocument(property.get(DataReader.DATA_ELEMENT));
+						}
+					}
+
+				}
+
+				checkIndicesWithDocument(indexes, expectedDataOfDocument);
+
+			} else {
+				throw new IllegalArgumentException("Array of Indexes and Data are required.");
+			}
+		}
+	}
+
+	private static void checkIndicesWithDocument(List<GetRequestBuilder> indexes,
+												 Map<String, Object> expectedDataOfDocument) {
+		for (GetRequestBuilder getRequestBuilder : indexes) {
+
+			GetResponse dataOfDocumentResponse = getRequestBuilder.execute().actionGet();
+
+			checkExistenceOfDocument(getRequestBuilder, dataOfDocumentResponse);
+			checkDocumentEquality(expectedDataOfDocument, getRequestBuilder, dataOfDocumentResponse);
+
+		}
+	}
+
+	private static void checkDocumentEquality(Map<String, Object> expectedDataOfDocument,
+											  GetRequestBuilder getRequestBuilder, GetResponse dataOfDocumentResponse) {
+		final Map<String, Object> dataOfDocument = new LinkedHashMap<>(dataOfDocumentResponse.getSource());
+
+		if (!DeepEquals.deepEquals(dataOfDocument, expectedDataOfDocument)) {
+			try {
+				throw FailureHandler.createFailure("Expected document for index: %s - type: %s - id: %s is %s, but %s was found.", getRequestBuilder.request().index(), getRequestBuilder.request().type(),
+						getRequestBuilder.request().id(), OBJECT_MAPPER.writeValueAsString(expectedDataOfDocument), OBJECT_MAPPER.writeValueAsString(dataOfDocument));
+			} catch (IOException e) {
+				throw new IllegalArgumentException(e);
+			}
+		}
+	}
+
+	private static void checkExistenceOfDocument(GetRequestBuilder getRequestBuilder, GetResponse dataOfDocumentResponse) {
+		if (!dataOfDocumentResponse.isExists()) {
+			throw FailureHandler.createFailure(
+					"Document with index: %s - type: %s - id: %s has not returned any document.",
+					getRequestBuilder.request().index(), getRequestBuilder.request().type(),
+					getRequestBuilder.request().id());
+		}
+	}
+
+	private static void checkNumberOfDocuments(List<Map<String, Object>> expectedDocuments, Client client) {
+		int expectedNumberOfElements = expectedDocuments.size();
+
+		long numberOfInsertedDocuments = numberOfInsertedDocuments(client);
+
+		if (expectedNumberOfElements != numberOfInsertedDocuments) {
+			throw FailureHandler.createFailure("Expected number of documents are %s but %s has been found.",
+					expectedNumberOfElements, numberOfInsertedDocuments);
+		}
+	}
+
+	private static GetRequestBuilder prepareGetIndex(Object object, Client client) {
+		@SuppressWarnings("unchecked")
+		Map<String, String> indexInformation = (Map<String, String>) object;
+
+		GetRequestBuilder prepareGet = client.prepareGet();
+
+		if (indexInformation.containsKey(DataReader.INDEX_NAME_ELEMENT)) {
+			prepareGet.setIndex(indexInformation.get(DataReader.INDEX_NAME_ELEMENT));
+		}
+
+		if (indexInformation.containsKey(DataReader.INDEX_TYPE_ELEMENT)) {
+			prepareGet.setType(indexInformation.get(DataReader.INDEX_TYPE_ELEMENT));
+		}
+
+		if (indexInformation.containsKey(DataReader.INDEX_ID_ELEMENT)) {
+			prepareGet.setId(indexInformation.get(DataReader.INDEX_ID_ELEMENT));
+		}
+
+		return prepareGet;
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Map<String, Object> dataOfDocument(Object object) {
+		return (Map<String, Object>) object;
+	}
+
+	private static long numberOfInsertedDocuments(Client client) {
+		final CountResponse numberOfElements = client.prepareCount().execute().actionGet();
+		return numberOfElements.getCount();
+	}
+}

--- a/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/ElasticsearchComparisonStrategy.java
+++ b/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/ElasticsearchComparisonStrategy.java
@@ -1,0 +1,6 @@
+package com.lordofthejars.nosqlunit.elasticsearch2;
+
+import com.lordofthejars.nosqlunit.core.ComparisonStrategy;
+
+public interface ElasticsearchComparisonStrategy extends ComparisonStrategy<ElasticsearchConnectionCallback> {
+}

--- a/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/ElasticsearchConfiguration.java
+++ b/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/ElasticsearchConfiguration.java
@@ -1,0 +1,48 @@
+package com.lordofthejars.nosqlunit.elasticsearch2;
+
+import com.lordofthejars.nosqlunit.core.AbstractJsr330Configuration;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.settings.Settings;
+
+public class ElasticsearchConfiguration extends AbstractJsr330Configuration {
+	private static final String LOCALHOST = "localhost";
+	private static final int DEFAULT_PORT = 9300;
+
+	private String host = LOCALHOST;
+	private int port = DEFAULT_PORT;
+	private Settings settings = null;
+
+	private Client client;
+
+	public void setClient(Client client) {
+		this.client = client;
+	}
+
+	public Client getClient() {
+		return client;
+	}
+
+	public void setPort(int port) {
+		this.port = port;
+	}
+
+	public int getPort() {
+		return port;
+	}
+
+	public void setSettings(Settings settings) {
+		this.settings = settings;
+	}
+
+	public Settings getSettings() {
+		return settings;
+	}
+
+	public void setHost(String host) {
+		this.host = host;
+	}
+
+	public String getHost() {
+		return host;
+	}
+}

--- a/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/ElasticsearchConnectionCallback.java
+++ b/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/ElasticsearchConnectionCallback.java
@@ -1,0 +1,7 @@
+package com.lordofthejars.nosqlunit.elasticsearch2;
+
+import org.elasticsearch.client.Client;
+
+public interface ElasticsearchConnectionCallback {
+	Client nodeClient();
+}

--- a/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/ElasticsearchInsertionStrategy.java
+++ b/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/ElasticsearchInsertionStrategy.java
@@ -1,0 +1,6 @@
+package com.lordofthejars.nosqlunit.elasticsearch2;
+
+import com.lordofthejars.nosqlunit.core.InsertionStrategy;
+
+public interface ElasticsearchInsertionStrategy extends InsertionStrategy<ElasticsearchConnectionCallback> {
+}

--- a/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/ElasticsearchOperation.java
+++ b/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/ElasticsearchOperation.java
@@ -1,0 +1,128 @@
+package com.lordofthejars.nosqlunit.elasticsearch2;
+
+import com.google.common.primitives.Ints;
+import com.lordofthejars.nosqlunit.core.AbstractCustomizableDatabaseOperation;
+import com.lordofthejars.nosqlunit.core.NoSqlAssertionError;
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.count.CountResponse;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.SearchHit;
+
+import java.io.InputStream;
+import java.util.concurrent.TimeUnit;
+
+public class ElasticsearchOperation extends
+		AbstractCustomizableDatabaseOperation<ElasticsearchConnectionCallback, Client> {
+
+	private Client client;
+
+	public ElasticsearchOperation(Client client) {
+		this.client = client;
+		setInsertionStrategy(new DefaultElasticsearchInsertionStrategy());
+		setComparisonStrategy(new DefaultElasticsearchComparisonStrategy());
+	}
+
+	@Override
+	public void insert(InputStream dataScript) {
+		insertData(dataScript);
+	}
+
+	private void insertData(InputStream dataScript) {
+		try {
+			executeInsertion(new ElasticsearchConnectionCallback() {
+
+				@Override
+				public Client nodeClient() {
+					return client;
+				}
+			}, dataScript);
+		} catch (Throwable e) {
+			throw new IllegalArgumentException(e);
+		}
+	}
+
+	@Override
+	public void deleteAll() {
+		clearDocuments();
+	}
+
+	private void clearDocuments() {
+		if (isAnyIndexPresent()) {
+			final SearchResponse countResponse = client.prepareSearch()
+					.setSearchType(SearchType.QUERY_THEN_FETCH)
+					.setQuery(QueryBuilders.matchAllQuery())
+					.setSize(0)
+					.execute()
+					.actionGet();
+
+			int docCount = Ints.saturatedCast(countResponse.getHits().totalHits());
+			final SearchResponse scrollResponse = client.prepareSearch()
+					.setSearchType(SearchType.SCAN)
+					.setScroll(new TimeValue(1L, TimeUnit.MINUTES))
+					.setQuery(QueryBuilders.matchAllQuery())
+					.setSize(docCount)
+					.execute()
+					.actionGet();
+
+			final BulkRequestBuilder bulkRequestBuilder = client.prepareBulk();
+			while (true) {
+				final SearchResponse searchResponse = client.prepareSearchScroll(scrollResponse.getScrollId())
+						.setScroll(new TimeValue(1L, TimeUnit.MINUTES))
+						.execute()
+						.actionGet();
+
+				for (SearchHit hit : searchResponse.getHits().getHits()) {
+					bulkRequestBuilder.add(client.prepareDelete(hit.index(), hit.type(), hit.id()));
+				}
+
+				//Break condition: No hits are returned
+				if (searchResponse.getHits().getHits().length == 0) {
+					break;
+				}
+			}
+
+			if (bulkRequestBuilder.numberOfActions() > 0) {
+				final BulkResponse bulkResponse = bulkRequestBuilder.execute().actionGet();
+			}
+
+			refreshNode();
+		}
+
+	}
+
+	private boolean isAnyIndexPresent() {
+		CountResponse numberOfElements = client.prepareCount().execute().actionGet();
+		return numberOfElements.getCount() > 0;
+	}
+
+	private void refreshNode() {
+		client.admin().indices().prepareRefresh().execute().actionGet();
+	}
+
+	@Override
+	public boolean databaseIs(InputStream expectedData) {
+		try {
+			return executeComparison(new ElasticsearchConnectionCallback() {
+
+				@Override
+				public Client nodeClient() {
+					return client;
+				}
+			}, expectedData);
+		} catch (NoSqlAssertionError e) {
+			throw e;
+		} catch (Throwable e) {
+			throw new IllegalStateException(e);
+		}
+	}
+
+	@Override
+	public Client connectionManager() {
+		return client;
+	}
+}

--- a/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/ElasticsearchRule.java
+++ b/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/ElasticsearchRule.java
@@ -1,0 +1,76 @@
+package com.lordofthejars.nosqlunit.elasticsearch2;
+
+
+import com.lordofthejars.nosqlunit.core.AbstractNoSqlTestRule;
+import com.lordofthejars.nosqlunit.core.DatabaseOperation;
+import org.elasticsearch.client.Client;
+
+public class ElasticsearchRule extends AbstractNoSqlTestRule {
+
+	private static final String EXTENSION = "json";
+
+	private DatabaseOperation<? extends Client> databaseOperation;
+
+	public static class ElasticsearchRuleBuilder {
+
+		private ElasticsearchConfiguration elasticsearchConfiguration;
+		private Object target;
+
+		private ElasticsearchRuleBuilder() {
+		}
+
+		public static ElasticsearchRuleBuilder newElasticsearchRule() {
+			return new ElasticsearchRuleBuilder();
+		}
+
+		public ElasticsearchRuleBuilder configure(ElasticsearchConfiguration elasticsearchConfiguration) {
+			this.elasticsearchConfiguration = elasticsearchConfiguration;
+			return this;
+		}
+
+		public ElasticsearchRuleBuilder unitInstance(Object target) {
+			this.target = target;
+			return this;
+		}
+
+		public ElasticsearchRule defaultEmbeddedElasticsearch() {
+			return new ElasticsearchRule(EmbeddedElasticsearchConfigurationBuilder.embeddedElasticsearch().build());
+		}
+
+		public ElasticsearchRule defaultManagedElasticsearch() {
+			return new ElasticsearchRule(ManagedElasticsearchConfigurationBuilder.managedElasticsearch().build());
+		}
+
+		public ElasticsearchRule build() {
+
+			if (this.elasticsearchConfiguration == null) {
+				throw new IllegalArgumentException("Configuration object should be provided.");
+			}
+
+			return new ElasticsearchRule(elasticsearchConfiguration, target);
+		}
+
+	}
+
+	public ElasticsearchRule(ElasticsearchConfiguration elasticsearchConfiguration) {
+		super(elasticsearchConfiguration.getConnectionIdentifier());
+		this.databaseOperation = new ElasticsearchOperation(elasticsearchConfiguration.getClient());
+	}
+
+	/*With JUnit 10 is impossible to get target from a Rule, it seems that future versions will support it. For now constructor is apporach is the only way.*/
+	public ElasticsearchRule(ElasticsearchConfiguration elasticsearchConfiguration, Object target) {
+		this(elasticsearchConfiguration);
+		setTarget(target);
+	}
+
+	@Override
+	public DatabaseOperation getDatabaseOperation() {
+		return this.databaseOperation;
+	}
+
+	@Override
+	public String getWorkingExtension() {
+		return EXTENSION;
+	}
+
+}

--- a/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/EmbeddedElasticsearch.java
+++ b/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/EmbeddedElasticsearch.java
@@ -1,0 +1,87 @@
+package com.lordofthejars.nosqlunit.elasticsearch2;
+
+import org.elasticsearch.common.settings.Settings;
+import org.junit.rules.ExternalResource;
+
+import java.io.File;
+
+public class EmbeddedElasticsearch extends ExternalResource {
+
+	private EmbeddedElasticsearch() {
+		super();
+	}
+
+	protected EmbeddedElasticsearchLifecycleManager elasticsearchLifecycleManager;
+
+	public static class EmbeddedElasticsearchRuleBuilder {
+
+		private EmbeddedElasticsearchLifecycleManager elasticsearchLifecycleManager;
+
+		private EmbeddedElasticsearchRuleBuilder() {
+			this.elasticsearchLifecycleManager = new EmbeddedElasticsearchLifecycleManager();
+		}
+
+		public static EmbeddedElasticsearchRuleBuilder newEmbeddedElasticsearchRule() {
+			return new EmbeddedElasticsearchRuleBuilder();
+		}
+
+		public EmbeddedElasticsearchRuleBuilder homePath(File homePath) {
+			this.elasticsearchLifecycleManager.setHomePath(homePath);
+			return this;
+		}
+
+		public EmbeddedElasticsearchRuleBuilder targetPath(File targetPath) {
+			this.elasticsearchLifecycleManager.setDataPath(targetPath);
+			return this;
+		}
+
+		public EmbeddedElasticsearchRuleBuilder clusterName(String clusterName) {
+			this.elasticsearchLifecycleManager.setClusterName(clusterName);
+			return this;
+		}
+
+		public EmbeddedElasticsearchRuleBuilder client(boolean client) {
+			this.elasticsearchLifecycleManager.setClient(client);
+			return this;
+		}
+
+		public EmbeddedElasticsearchRuleBuilder settings(Settings settings) {
+			this.elasticsearchLifecycleManager.setSettings(settings);
+			return this;
+		}
+
+		public EmbeddedElasticsearchRuleBuilder local(boolean local) {
+			this.elasticsearchLifecycleManager.setLocal(local);
+			return this;
+		}
+
+		public EmbeddedElasticsearchRuleBuilder data(boolean data) {
+			this.elasticsearchLifecycleManager.setData(data);
+			return this;
+		}
+
+		public EmbeddedElasticsearch build() {
+
+			if (this.elasticsearchLifecycleManager.getDataPath() == null) {
+				throw new IllegalArgumentException("No Path to Embedded Elasticsearch is provided.");
+			}
+
+			EmbeddedElasticsearch embeddedElasticsearch = new EmbeddedElasticsearch();
+			embeddedElasticsearch.elasticsearchLifecycleManager = this.elasticsearchLifecycleManager;
+
+			return embeddedElasticsearch;
+
+		}
+
+	}
+
+	@Override
+	protected void before() throws Throwable {
+		this.elasticsearchLifecycleManager.startEngine();
+	}
+
+	@Override
+	protected void after() {
+		this.elasticsearchLifecycleManager.stopEngine();
+	}
+}

--- a/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/EmbeddedElasticsearchConfigurationBuilder.java
+++ b/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/EmbeddedElasticsearchConfigurationBuilder.java
@@ -1,0 +1,30 @@
+package com.lordofthejars.nosqlunit.elasticsearch2;
+
+import com.lordofthejars.nosqlunit.core.FailureHandler;
+import org.elasticsearch.node.Node;
+
+public class EmbeddedElasticsearchConfigurationBuilder {
+
+	private ElasticsearchConfiguration elasticsearchConfiguration = new ElasticsearchConfiguration();
+
+	public static EmbeddedElasticsearchConfigurationBuilder embeddedElasticsearch() {
+		return new EmbeddedElasticsearchConfigurationBuilder();
+	}
+
+	public EmbeddedElasticsearchConfigurationBuilder connectionIdentifier(String connectionIdentifier) {
+		elasticsearchConfiguration.setConnectionIdentifier(connectionIdentifier);
+		return this;
+	}
+
+	public ElasticsearchConfiguration build() {
+
+		Node defaultEmbeddedInstance = EmbeddedElasticsearchInstancesFactory.getInstance().getDefaultEmbeddedInstance();
+
+		if (defaultEmbeddedInstance == null) {
+			throw FailureHandler.createIllegalStateFailure("There is no EmbeddedElasticsearch rule with default target defined during test execution. Please create one using @Rule or @ClassRule before executing these tests.");
+		}
+
+		this.elasticsearchConfiguration.setClient(defaultEmbeddedInstance.client());
+		return this.elasticsearchConfiguration;
+	}
+}

--- a/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/EmbeddedElasticsearchInstancesFactory.java
+++ b/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/EmbeddedElasticsearchInstancesFactory.java
@@ -1,0 +1,20 @@
+package com.lordofthejars.nosqlunit.elasticsearch2;
+
+import com.lordofthejars.nosqlunit.util.EmbeddedInstances;
+import org.elasticsearch.node.Node;
+
+public class EmbeddedElasticsearchInstancesFactory {
+	private static EmbeddedInstances<Node> embeddedInstances;
+
+	private EmbeddedElasticsearchInstancesFactory() {
+	}
+
+	public synchronized static EmbeddedInstances<Node> getInstance() {
+		if (embeddedInstances == null) {
+			embeddedInstances = new EmbeddedInstances<>();
+		}
+
+		return embeddedInstances;
+	}
+
+}

--- a/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/EmbeddedElasticsearchLifecycleManager.java
+++ b/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/EmbeddedElasticsearchLifecycleManager.java
@@ -1,0 +1,111 @@
+package com.lordofthejars.nosqlunit.elasticsearch2;
+
+import com.google.common.io.Files;
+import com.lordofthejars.nosqlunit.core.AbstractLifecycleManager;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.node.Node;
+import org.elasticsearch.node.NodeBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+
+import static org.elasticsearch.node.NodeBuilder.nodeBuilder;
+
+public class EmbeddedElasticsearchLifecycleManager extends AbstractLifecycleManager {
+	private static final Logger LOGGER = LoggerFactory.getLogger(EmbeddedElasticsearchLifecycleManager.class);
+	private static final String LOCALHOST = "127.0.0.1";
+	private static final int DEFAULT_PORT = 9300;
+	private static final String HOME_PATH_PROPERTY = "path.home";
+	private static final String DATA_PATH_PROPERTY = "path.data";
+
+	public static final File EMBEDDED_ELASTICSEARCH_HOME_PATH = Files.createTempDir();
+	public static final File EMBEDDED_ELASTICSEARCH_DATA_PATH = new File(EMBEDDED_ELASTICSEARCH_HOME_PATH, "data");
+
+	private File homePath = EMBEDDED_ELASTICSEARCH_HOME_PATH;
+	private File dataPath = EMBEDDED_ELASTICSEARCH_DATA_PATH;
+
+	private NodeBuilder nodeBuilder;
+
+	public EmbeddedElasticsearchLifecycleManager() {
+		nodeBuilder = nodeBuilder().local(true);
+	}
+
+	@Override
+	public String getHost() {
+		return LOCALHOST + dataPath;
+	}
+
+	@Override
+	public int getPort() {
+		return DEFAULT_PORT;
+	}
+
+	@Override
+	public void doStart() throws Throwable {
+		LOGGER.info("Starting Embedded Elasticsearch instance.");
+
+		nodeBuilder.getSettings()
+				.put(HOME_PATH_PROPERTY, homePath)
+				.put(DATA_PATH_PROPERTY, dataPath);
+		Node node = elasticsearchNode();
+		EmbeddedElasticsearchInstancesFactory.getInstance().addEmbeddedInstance(node, dataPath.getAbsolutePath());
+
+		LOGGER.info("Started Embedded Elasticsearch instance.");
+	}
+
+	private Node elasticsearchNode() {
+		return nodeBuilder.node();
+	}
+
+	@Override
+	public void doStop() {
+		LOGGER.info("Stopping Embedded Elasticsearch instance.");
+
+		Node node = EmbeddedElasticsearchInstancesFactory.getInstance().getEmbeddedByTargetPath(dataPath.getAbsolutePath());
+
+		if (node != null) {
+			node.close();
+		}
+
+		EmbeddedElasticsearchInstancesFactory.getInstance().removeEmbeddedInstance(dataPath.getAbsolutePath());
+		LOGGER.info("Stopped Embedded Elasticsearch instance.");
+
+	}
+
+	public void setSettings(Settings settings) {
+		nodeBuilder.settings(settings);
+	}
+
+	public void setClient(boolean client) {
+		nodeBuilder.client(client);
+	}
+
+	public void setClusterName(String clusterName) {
+		nodeBuilder.clusterName(clusterName);
+	}
+
+	public void setData(boolean data) {
+		nodeBuilder.data(data);
+	}
+
+	public void setLocal(boolean local) {
+		nodeBuilder.local(local);
+	}
+
+	public File getDataPath() {
+		return dataPath;
+	}
+
+	public void setDataPath(File dataPath) {
+		this.dataPath = dataPath;
+	}
+
+	public File getHomePath() {
+		return homePath;
+	}
+
+	public void setHomePath(File homePath) {
+		this.homePath = homePath;
+	}
+}

--- a/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/LowLevelElasticSearchOperations.java
+++ b/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/LowLevelElasticSearchOperations.java
@@ -1,0 +1,29 @@
+package com.lordofthejars.nosqlunit.elasticsearch2;
+
+import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.common.transport.InetSocketTransportAddress;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
+
+public class LowLevelElasticSearchOperations {
+	private static final int NUM_RETRIES_TO_CHECK_SERVER_UP = 3;
+
+	public boolean assertThatConnectionToElasticsearchIsPossible(String host, int port) throws InterruptedException {
+		final InetSocketAddress address = new InetSocketAddress(host, port);
+
+		try (TransportClient transportClient = TransportClient.builder().build()) {
+			transportClient.addTransportAddress(new InetSocketTransportAddress(address));
+			for (int i = 0; i < NUM_RETRIES_TO_CHECK_SERVER_UP; i++) {
+				try {
+					transportClient.admin().cluster().prepareState().execute().actionGet();
+					return true;
+				} catch (Exception e) {
+					TimeUnit.SECONDS.sleep(7);
+				}
+			}
+		}
+
+		return false;
+	}
+}

--- a/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/ManagedElasticsearch.java
+++ b/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/ManagedElasticsearch.java
@@ -1,0 +1,78 @@
+package com.lordofthejars.nosqlunit.elasticsearch2;
+
+import org.junit.rules.ExternalResource;
+
+public class ManagedElasticsearch extends ExternalResource {
+
+	private ManagedElasticsearch() {
+		super();
+	}
+
+	protected ManagedElasticsearchLifecycleManager managedElasticsearchLifecycleManager;
+
+	public static class ManagedElasticsearchRuleBuilder {
+
+		private ManagedElasticsearchLifecycleManager managedElasticsearchLifecycleManager;
+
+		private ManagedElasticsearchRuleBuilder() {
+			this.managedElasticsearchLifecycleManager = new ManagedElasticsearchLifecycleManager();
+		}
+
+		public static ManagedElasticsearchRuleBuilder newManagedElasticsearchRule() {
+			return new ManagedElasticsearchRuleBuilder();
+		}
+
+		public ManagedElasticsearchRuleBuilder elasticsearchPath(String elasticsearchPath) {
+			this.managedElasticsearchLifecycleManager.setElasticsearchPath(elasticsearchPath);
+			return this;
+		}
+
+		public ManagedElasticsearchRuleBuilder port(int port) {
+			this.managedElasticsearchLifecycleManager.setPort(port);
+			return this;
+		}
+
+
+		public ManagedElasticsearchRuleBuilder targetPath(String targetPath) {
+			this.managedElasticsearchLifecycleManager.setTargetPath(targetPath);
+			return this;
+		}
+
+
+		public ManagedElasticsearchRuleBuilder appendCommandLineArguments(
+				String argumentName, String argumentValue) {
+			this.managedElasticsearchLifecycleManager.addExtraCommandLineArgument(argumentName,
+					argumentValue);
+			return this;
+		}
+
+		public ManagedElasticsearchRuleBuilder appendSingleCommandLineArguments(
+				String argument) {
+			this.managedElasticsearchLifecycleManager.addSingleCommandLineArgument(argument);
+			return this;
+		}
+
+
+		public ManagedElasticsearch build() {
+			if (this.managedElasticsearchLifecycleManager.getElasticsearchPath() == null) {
+				throw new IllegalArgumentException(
+						"No Path to Elasticsearch is provided.");
+			}
+
+			ManagedElasticsearch managedElasticsearch = new ManagedElasticsearch();
+			managedElasticsearch.managedElasticsearchLifecycleManager = this.managedElasticsearchLifecycleManager;
+
+			return managedElasticsearch;
+		}
+	}
+
+	@Override
+	protected void before() throws Throwable {
+		this.managedElasticsearchLifecycleManager.startEngine();
+	}
+
+	@Override
+	protected void after() {
+		this.managedElasticsearchLifecycleManager.stopEngine();
+	}
+}

--- a/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/ManagedElasticsearchConfigurationBuilder.java
+++ b/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/ManagedElasticsearchConfigurationBuilder.java
@@ -1,0 +1,51 @@
+package com.lordofthejars.nosqlunit.elasticsearch2;
+
+import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.InetSocketTransportAddress;
+
+import java.net.InetSocketAddress;
+
+
+public class ManagedElasticsearchConfigurationBuilder {
+	private ElasticsearchConfiguration elasticsearchConfiguration = new ElasticsearchConfiguration();
+
+	private ManagedElasticsearchConfigurationBuilder() {
+		super();
+	}
+
+	public static ManagedElasticsearchConfigurationBuilder managedElasticsearch() {
+		return new ManagedElasticsearchConfigurationBuilder();
+	}
+
+	public ManagedElasticsearchConfigurationBuilder port(int port) {
+		this.elasticsearchConfiguration.setPort(port);
+		return this;
+	}
+
+	public ManagedElasticsearchConfigurationBuilder settings(Settings settings) {
+		this.elasticsearchConfiguration.setSettings(settings);
+		return this;
+	}
+
+	public ManagedElasticsearchConfigurationBuilder connectionIdentifier(String connectionIdentifier) {
+		this.elasticsearchConfiguration.setConnectionIdentifier(connectionIdentifier);
+		return this;
+	}
+
+	public ElasticsearchConfiguration build() {
+		final InetSocketAddress address = new InetSocketAddress(this.elasticsearchConfiguration.getHost(), this.elasticsearchConfiguration.getPort());
+		final TransportClient client = getClient().addTransportAddress(new InetSocketTransportAddress(address));
+		this.elasticsearchConfiguration.setClient(client);
+
+		return this.elasticsearchConfiguration;
+	}
+
+	private TransportClient getClient() {
+		if (this.elasticsearchConfiguration.getSettings() == null) {
+			return TransportClient.builder().build();
+		} else {
+			return TransportClient.builder().settings(this.elasticsearchConfiguration.getSettings()).build();
+		}
+	}
+}

--- a/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/ManagedElasticsearchLifecycleManager.java
+++ b/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/ManagedElasticsearchLifecycleManager.java
@@ -1,0 +1,246 @@
+package com.lordofthejars.nosqlunit.elasticsearch2;
+
+import com.google.common.io.Files;
+import com.lordofthejars.nosqlunit.core.AbstractLifecycleManager;
+import com.lordofthejars.nosqlunit.core.CommandLineExecutor;
+import com.lordofthejars.nosqlunit.core.OperatingSystem;
+import com.lordofthejars.nosqlunit.core.OperatingSystemFamily;
+import com.lordofthejars.nosqlunit.core.OperatingSystemResolver;
+import com.lordofthejars.nosqlunit.core.OsNameSystemPropertyOperatingSystemResolver;
+import com.lordofthejars.nosqlunit.env.SystemEnvironmentVariables;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+
+import static com.lordofthejars.nosqlunit.core.IOUtils.deleteDir;
+
+public class ManagedElasticsearchLifecycleManager extends AbstractLifecycleManager {
+	private static final Logger LOGGER = LoggerFactory.getLogger(ManagedElasticsearchLifecycleManager.class);
+
+	private static final String DEFAULT_HOST = "localhost";
+	protected static final int DEFAULT_PORT = 9300;
+	protected static final String DEFAULT_ELASTICSEARCH_TARGET_PATH = Files.createTempDir().getAbsolutePath();
+	protected static final String FOREGROUND_OPTION = "-f";
+	private static final String ELASTICSEARCH_BINARY_DIRECTORY = "bin";
+
+	private static final String ELASTICSEARCH_EXECUTABLE_X = "elasticsearch";
+	private static final String ELASTICSEARCH_EXECUTABLE_W = "elasticsearch.bat";
+
+	private Map<String, String> extraCommandArguments = new HashMap<String, String>();
+	private List<String> singleCommandArguments = new ArrayList<String>();
+
+	private CommandLineExecutor commandLineExecutor = new CommandLineExecutor();
+	private OperatingSystemResolver operatingSystemResolver = new OsNameSystemPropertyOperatingSystemResolver();
+	private LowLevelElasticSearchOperations lowLevelElasticSearchOperations = new LowLevelElasticSearchOperations();
+
+	private String elasticsearchPath = SystemEnvironmentVariables.getEnvironmentOrPropertyVariable("ES_HOME");
+	private int port = DEFAULT_PORT;
+
+	private String targetPath = DEFAULT_ELASTICSEARCH_TARGET_PATH;
+
+	private ProcessRunnable processRunnable;
+
+	public ManagedElasticsearchLifecycleManager() {
+		super();
+	}
+
+	@Override
+	public String getHost() {
+		return DEFAULT_HOST;
+	}
+
+	@Override
+	public int getPort() {
+		return port;
+	}
+
+	@Override
+	public void doStart() throws Throwable {
+
+		LOGGER.info("Starting {} Elasticsearch instance.", elasticsearchPath);
+
+		File dbPath = ensureDbPathDoesNotExitsAndReturnCompositePath();
+
+		if (dbPath.mkdirs()) {
+			startElasticsearchAsADaemon();
+			boolean isServerUp = this.lowLevelElasticSearchOperations.assertThatConnectionToElasticsearchIsPossible(DEFAULT_HOST, DEFAULT_PORT);
+
+			if (!isServerUp) {
+				throw new IllegalStateException("Couldn't establish a connection with " + this.elasticsearchPath
+						+ " server at /127.0.0.1:" + port);
+			}
+
+		} else {
+			throw new IllegalStateException("Db Path " + dbPath + " could not be created.");
+		}
+
+		LOGGER.info("Started {} Elasticsearch instance.", elasticsearchPath);
+	}
+
+
+	private void startElasticsearchAsADaemon() throws InterruptedException {
+		CountDownLatch processIsReady = new CountDownLatch(1);
+		processRunnable = new ProcessRunnable(processIsReady);
+		Thread thread = new Thread(processRunnable);
+		thread.start();
+		processIsReady.await();
+	}
+
+	@Override
+	public void doStop() {
+		LOGGER.info("Stopping {} Elasticsearch instance.", elasticsearchPath);
+
+		try {
+			if (this.processRunnable != null) {
+				this.processRunnable.destroyProcess();
+			}
+		} finally {
+			ensureDbPathDoesNotExitsAndReturnCompositePath();
+		}
+
+		LOGGER.info("Stopped {} Elasticsearch instance.", elasticsearchPath);
+	}
+
+	private List<String> buildOperationSystemProgramAndArguments() {
+
+		List<String> programAndArguments = new ArrayList<String>();
+
+		programAndArguments.add(getExecutablePath());
+
+		if (isXBased()) {
+			programAndArguments.add(FOREGROUND_OPTION);
+		}
+
+		for (String argument : this.singleCommandArguments) {
+			programAndArguments.add(argument);
+		}
+
+		for (String argumentName : this.extraCommandArguments.keySet()) {
+			programAndArguments.add(argumentName);
+			programAndArguments.add(this.extraCommandArguments.get(argumentName));
+		}
+
+		return programAndArguments;
+
+	}
+
+	private boolean isXBased() {
+		OperatingSystemFamily family = this.operatingSystemResolver.currentOperatingSystem().getFamily();
+		return family != OperatingSystemFamily.WINDOWS;
+	}
+
+	private String getExecutablePath() {
+		return this.elasticsearchPath + File.separatorChar + ELASTICSEARCH_BINARY_DIRECTORY + File.separatorChar
+				+ elasticsearchExecutable();
+	}
+
+	private File ensureDbPathDoesNotExitsAndReturnCompositePath() {
+		File dbPath = new File(targetPath);
+		if (dbPath.exists()) {
+			deleteDir(dbPath);
+		}
+		return dbPath;
+	}
+
+	private String elasticsearchExecutable() {
+		OperatingSystem operatingSystem = this.operatingSystemResolver.currentOperatingSystem();
+
+		switch (operatingSystem.getFamily()) {
+			case WINDOWS:
+				return ELASTICSEARCH_EXECUTABLE_W;
+			default:
+				return ELASTICSEARCH_EXECUTABLE_X;
+		}
+
+	}
+
+	public void setPort(int port) {
+		this.port = port;
+	}
+
+	public void setElasticsearchPath(String elasticsearchPath) {
+		this.elasticsearchPath = elasticsearchPath;
+	}
+
+	public void setTargetPath(String targetPath) {
+		this.targetPath = targetPath;
+	}
+
+	public void addExtraCommandLineArgument(String argumentName,
+											String argumentValue) {
+		this.extraCommandArguments.put(argumentName, argumentValue);
+	}
+
+	public void addSingleCommandLineArgument(String argument) {
+		this.singleCommandArguments.add(argument);
+	}
+
+	public String getElasticsearchPath() {
+		return elasticsearchPath;
+	}
+
+	protected void setCommandLineExecutor(CommandLineExecutor commandLineExecutor) {
+		this.commandLineExecutor = commandLineExecutor;
+	}
+
+	protected void setOperatingSystemResolver(OperatingSystemResolver operatingSystemResolver) {
+		this.operatingSystemResolver = operatingSystemResolver;
+	}
+
+	protected void setLowLevelElasticSearchOperations(LowLevelElasticSearchOperations lowLevelElasticSearchOperations) {
+		this.lowLevelElasticSearchOperations = lowLevelElasticSearchOperations;
+	}
+
+	public class ProcessRunnable implements Runnable {
+
+		private CountDownLatch processIsReady;
+
+		private Process process;
+
+		public ProcessRunnable(CountDownLatch processIsReady) {
+			this.processIsReady = processIsReady;
+		}
+
+		@Override
+		public void run() {
+			try {
+				process = startProcess();
+			} catch (IOException e) {
+				throw prepareException(e);
+			} finally {
+				processIsReady.countDown();
+			}
+
+			try {
+				process.waitFor();
+
+			} catch (InterruptedException ie) {
+				throw prepareException(ie);
+			}
+
+		}
+
+		public void destroyProcess() {
+			if (this.process != null) {
+				this.process.destroy();
+			}
+		}
+
+		private IllegalStateException prepareException(Exception e) {
+			return new IllegalStateException("Elasticsearch [" + elasticsearchPath
+					+ "] could not be started. Next console message was thrown: " + e.getMessage());
+		}
+
+		private Process startProcess() throws IOException {
+			return commandLineExecutor.startProcessInDirectoryAndArguments(targetPath,
+					buildOperationSystemProgramAndArguments());
+		}
+	}
+}

--- a/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/RemoteElasticsearchConfigurationBuilder.java
+++ b/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/RemoteElasticsearchConfigurationBuilder.java
@@ -1,0 +1,56 @@
+package com.lordofthejars.nosqlunit.elasticsearch2;
+
+import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.InetSocketTransportAddress;
+
+import java.net.InetSocketAddress;
+
+public class RemoteElasticsearchConfigurationBuilder {
+
+	private ElasticsearchConfiguration elasticsearchConfiguration = new ElasticsearchConfiguration();
+
+	private RemoteElasticsearchConfigurationBuilder() {
+		super();
+	}
+
+	public static RemoteElasticsearchConfigurationBuilder remoteElasticsearch() {
+		return new RemoteElasticsearchConfigurationBuilder();
+	}
+
+	public RemoteElasticsearchConfigurationBuilder port(int port) {
+		this.elasticsearchConfiguration.setPort(port);
+		return this;
+	}
+
+	public RemoteElasticsearchConfigurationBuilder host(String host) {
+		this.elasticsearchConfiguration.setHost(host);
+		return this;
+	}
+
+	public RemoteElasticsearchConfigurationBuilder settings(Settings settings) {
+		this.elasticsearchConfiguration.setSettings(settings);
+		return this;
+	}
+
+	public RemoteElasticsearchConfigurationBuilder connectionIdentifier(String connectionIdentifier) {
+		this.elasticsearchConfiguration.setConnectionIdentifier(connectionIdentifier);
+		return this;
+	}
+
+	public ElasticsearchConfiguration build() {
+		final InetSocketAddress address = new InetSocketAddress(this.elasticsearchConfiguration.getHost(), this.elasticsearchConfiguration.getPort());
+		final TransportClient client = getClient().addTransportAddress(new InetSocketTransportAddress(address));
+		this.elasticsearchConfiguration.setClient(client);
+
+		return this.elasticsearchConfiguration;
+	}
+
+	private TransportClient getClient() {
+		if (this.elasticsearchConfiguration.getSettings() == null) {
+			return TransportClient.builder().build();
+		} else {
+			return TransportClient.builder().settings(this.elasticsearchConfiguration.getSettings()).build();
+		}
+	}
+}

--- a/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/parser/DataReader.java
+++ b/nosqlunit-elasticsearch2/src/main/java/com/lordofthejars/nosqlunit/elasticsearch2/parser/DataReader.java
@@ -1,0 +1,121 @@
+package com.lordofthejars.nosqlunit.elasticsearch2.parser;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.type.TypeReference;
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.client.Client;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DataReader {
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+
+	public static final String DOCUMENTS_ELEMENT = "documents";
+	public static final String DOCUMENT_ELEMENT = "document";
+	public static final String DATA_ELEMENT = "data";
+	public static final String INDEX_ELEMENT = "index";
+	public static final String INDEX_NAME_ELEMENT = "indexName";
+	public static final String INDEX_TYPE_ELEMENT = "indexType";
+	public static final String INDEX_ID_ELEMENT = "indexId";
+
+	private Client client;
+
+	public DataReader(Client client) {
+		this.client = client;
+	}
+
+	public void read(InputStream data) {
+		try {
+			final List<Map<String, Object>> documents = getDocuments(data);
+			insertDocuments(documents);
+			refreshNode();
+		} catch (IOException e) {
+			throw new IllegalArgumentException(e);
+		}
+	}
+
+	private void refreshNode() {
+		client.admin().indices().prepareRefresh().execute().actionGet();
+	}
+
+	private void insertDocuments(List<Map<String, Object>> documents) {
+		for (Map<String, Object> document : documents) {
+			final Object object = document.get(DOCUMENT_ELEMENT);
+
+			if (object instanceof List) {
+				@SuppressWarnings("unchecked")
+				final List<Map<String, Object>> properties = (List<Map<String, Object>>) object;
+				insertDocument(properties);
+			} else {
+				throw new IllegalArgumentException("Array of Indexes and Data are required.");
+			}
+		}
+	}
+
+	private void insertDocument(List<Map<String, Object>> properties) {
+		final List<IndexRequestBuilder> indexes = new ArrayList<>();
+		Map<String, Object> dataOfDocument = new HashMap<>();
+
+		for (Map<String, Object> property : properties) {
+			if (property.containsKey(INDEX_ELEMENT)) {
+				indexes.add(createIndex(property.get(INDEX_ELEMENT)));
+			} else {
+				if (property.containsKey(DATA_ELEMENT)) {
+					dataOfDocument = dataOfDocument(property.get(DATA_ELEMENT));
+				}
+			}
+		}
+
+		insertIndexes(indexes, dataOfDocument);
+	}
+
+	private void insertIndexes(List<IndexRequestBuilder> indexes, Map<String, Object> dataOfDocument) {
+		for (IndexRequestBuilder indexRequestBuilder : indexes) {
+			indexRequestBuilder.setSource(dataOfDocument).execute().actionGet();
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private Map<String, Object> dataOfDocument(Object object) {
+		return (Map<String, Object>) object;
+	}
+
+	private IndexRequestBuilder createIndex(Object object) {
+		@SuppressWarnings("unchecked")
+		final Map<String, String> indexInformation = (Map<String, String>) object;
+
+		final IndexRequestBuilder prepareIndex = client.prepareIndex();
+
+		if (indexInformation.containsKey(INDEX_NAME_ELEMENT)) {
+			prepareIndex.setIndex(indexInformation.get(INDEX_NAME_ELEMENT));
+		}
+
+		if (indexInformation.containsKey(INDEX_TYPE_ELEMENT)) {
+			prepareIndex.setType(indexInformation.get(INDEX_TYPE_ELEMENT));
+		}
+
+		if (indexInformation.containsKey(INDEX_ID_ELEMENT)) {
+			prepareIndex.setId(indexInformation.get(INDEX_ID_ELEMENT));
+		}
+
+		return prepareIndex;
+	}
+
+	@SuppressWarnings("unchecked")
+	public static List<Map<String, Object>> getDocuments(InputStream data) throws IOException {
+		final Map<String, Object> rootNode = MAPPER.readValue(data, new TypeReference<Map<String, Object>>() {
+		});
+		final Object dataElements = rootNode.get(DOCUMENTS_ELEMENT);
+
+		if (dataElements instanceof List) {
+			return (List<Map<String, Object>>) dataElements;
+		} else {
+			throw new IllegalArgumentException("Array of documents are required.");
+		}
+	}
+}

--- a/nosqlunit-elasticsearch2/src/test/java/com/lordofthejars/nosqlunit/elasticsearch2/WhenManagedElasticsearchLifecycleIsManaged.java
+++ b/nosqlunit-elasticsearch2/src/test/java/com/lordofthejars/nosqlunit/elasticsearch2/WhenManagedElasticsearchLifecycleIsManaged.java
@@ -1,0 +1,166 @@
+package com.lordofthejars.nosqlunit.elasticsearch2;
+
+import com.lordofthejars.nosqlunit.core.CommandLineExecutor;
+import com.lordofthejars.nosqlunit.core.ConnectionManagement;
+import com.lordofthejars.nosqlunit.core.OperatingSystem;
+import com.lordofthejars.nosqlunit.core.OperatingSystemResolver;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.lordofthejars.nosqlunit.elasticsearch2.ManagedElasticsearch.ManagedElasticsearchRuleBuilder.newManagedElasticsearchRule;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+public class WhenManagedElasticsearchLifecycleIsManaged {
+	private static final String DEFAULT_ELASTICSEARCH_HOME = "/opt/elasticsearch-2.0.0-beta1/";
+	private static final String ES_HOME = System.getProperty("ES_HOME", DEFAULT_ELASTICSEARCH_HOME);
+	private static final Path ES_HOME_PATH = Paths.get(ES_HOME);
+
+	@Mock
+	private OperatingSystemResolver operatingSystemResolver;
+
+	@Mock
+	private LowLevelElasticSearchOperations lowLevelElasticSearchOperations;
+
+	@Before
+	public void setUp() {
+		MockitoAnnotations.initMocks(this);
+	}
+
+	@Test
+	public void managed_elasticsearch_should_be_started_from_elasticsearch_home() throws Throwable {
+		final String oldElasticsearchHome = System.getProperty("ES_HOME");
+		if (oldElasticsearchHome == null) {
+			System.setProperty("ES_HOME", ES_HOME);
+		}
+
+		when(lowLevelElasticSearchOperations.assertThatConnectionToElasticsearchIsPossible(anyString(), anyInt())).thenReturn(true);
+		when(operatingSystemResolver.currentOperatingSystem()).thenReturn(OperatingSystem.LINUX_OS);
+
+		CommandLineExecutor commandLineExecutor = mock(CommandLineExecutor.class);
+
+		Process mockProcess = mock(Process.class);
+		when(mockProcess.exitValue()).thenReturn(0);
+
+		when(commandLineExecutor.startProcessInDirectoryAndArguments(anyString(), anyListOf(String.class))).thenReturn(mockProcess);
+
+		try {
+			ManagedElasticsearch managedElasticsearch = newManagedElasticsearchRule().build();
+			managedElasticsearch.managedElasticsearchLifecycleManager.setCommandLineExecutor(commandLineExecutor);
+			managedElasticsearch.managedElasticsearchLifecycleManager.setOperatingSystemResolver(operatingSystemResolver);
+			managedElasticsearch.managedElasticsearchLifecycleManager.setLowLevelElasticSearchOperations(lowLevelElasticSearchOperations);
+
+			managedElasticsearch.before();
+			managedElasticsearch.after();
+
+			verify(commandLineExecutor).startProcessInDirectoryAndArguments(ManagedElasticsearchLifecycleManager.DEFAULT_ELASTICSEARCH_TARGET_PATH,
+					getExpectedXCommand());
+		} finally {
+			if (oldElasticsearchHome == null) {
+				System.clearProperty("ES_HOME");
+			}
+		}
+	}
+
+	@Test
+	public void managed_elasticsearch_should_be_started_from_elasticsearch_custom_location() throws Throwable {
+		when(lowLevelElasticSearchOperations.assertThatConnectionToElasticsearchIsPossible(anyString(), anyInt())).thenReturn(true);
+		when(operatingSystemResolver.currentOperatingSystem()).thenReturn(OperatingSystem.LINUX_OS);
+
+		CommandLineExecutor commandLineExecutor = mock(CommandLineExecutor.class);
+
+		Process mockProcess = mock(Process.class);
+		when(mockProcess.exitValue()).thenReturn(0);
+
+		when(commandLineExecutor.startProcessInDirectoryAndArguments(anyString(), anyListOf(String.class))).thenReturn(mockProcess);
+
+		ManagedElasticsearch managedElasticsearch = newManagedElasticsearchRule().elasticsearchPath(ES_HOME).build();
+		managedElasticsearch.managedElasticsearchLifecycleManager.setCommandLineExecutor(commandLineExecutor);
+		managedElasticsearch.managedElasticsearchLifecycleManager.setOperatingSystemResolver(operatingSystemResolver);
+		managedElasticsearch.managedElasticsearchLifecycleManager.setLowLevelElasticSearchOperations(lowLevelElasticSearchOperations);
+
+		managedElasticsearch.before();
+		managedElasticsearch.after();
+
+		verify(commandLineExecutor).startProcessInDirectoryAndArguments(ManagedElasticsearchLifecycleManager.DEFAULT_ELASTICSEARCH_TARGET_PATH,
+				getExpectedXCommand());
+
+	}
+
+	@Test
+	public void managed_elasticsearch_should_be_started_from_windows_custom_location() throws Throwable {
+		when(lowLevelElasticSearchOperations.assertThatConnectionToElasticsearchIsPossible(anyString(), anyInt())).thenReturn(true);
+		when(operatingSystemResolver.currentOperatingSystem()).thenReturn(OperatingSystem.WINDOWS_7);
+
+		CommandLineExecutor commandLineExecutor = mock(CommandLineExecutor.class);
+
+		Process mockProcess = mock(Process.class);
+		when(mockProcess.exitValue()).thenReturn(0);
+
+		when(commandLineExecutor.startProcessInDirectoryAndArguments(anyString(), anyListOf(String.class))).thenReturn(mockProcess);
+
+		ManagedElasticsearch managedElasticsearch = newManagedElasticsearchRule().elasticsearchPath(ES_HOME).build();
+		managedElasticsearch.managedElasticsearchLifecycleManager.setCommandLineExecutor(commandLineExecutor);
+		managedElasticsearch.managedElasticsearchLifecycleManager.setOperatingSystemResolver(operatingSystemResolver);
+		managedElasticsearch.managedElasticsearchLifecycleManager.setLowLevelElasticSearchOperations(lowLevelElasticSearchOperations);
+
+		managedElasticsearch.before();
+		managedElasticsearch.after();
+
+		verify(commandLineExecutor).startProcessInDirectoryAndArguments(ManagedElasticsearchLifecycleManager.DEFAULT_ELASTICSEARCH_TARGET_PATH,
+				getExpectedWindowsCommand());
+
+	}
+
+	@Test
+	public void managed_elasticsearch_should_be_stopped() throws Throwable {
+		when(lowLevelElasticSearchOperations.assertThatConnectionToElasticsearchIsPossible(anyString(), anyInt())).thenReturn(true);
+		when(operatingSystemResolver.currentOperatingSystem()).thenReturn(OperatingSystem.LINUX_OS);
+
+		CommandLineExecutor commandLineExecutor = mock(CommandLineExecutor.class);
+
+		Process mockProcess = mock(Process.class);
+		when(mockProcess.exitValue()).thenReturn(0);
+
+		when(commandLineExecutor.startProcessInDirectoryAndArguments(anyString(), anyListOf(String.class))).thenReturn(mockProcess);
+
+		ManagedElasticsearch managedElasticsearch = newManagedElasticsearchRule().elasticsearchPath(ES_HOME).build();
+		managedElasticsearch.managedElasticsearchLifecycleManager.setCommandLineExecutor(commandLineExecutor);
+		managedElasticsearch.managedElasticsearchLifecycleManager.setOperatingSystemResolver(operatingSystemResolver);
+		managedElasticsearch.managedElasticsearchLifecycleManager.setLowLevelElasticSearchOperations(lowLevelElasticSearchOperations);
+
+		managedElasticsearch.before();
+		managedElasticsearch.after();
+
+		assertThat(ConnectionManagement.getInstance().isConnectionRegistered("127.0.0.1", ManagedElasticsearchLifecycleManager.DEFAULT_PORT), is(false));
+	}
+
+	private List<String> getExpectedWindowsCommand() {
+		final List<String> expectedCommand = new ArrayList<>();
+		expectedCommand.add(ES_HOME_PATH.resolve(Paths.get("bin", "elasticsearch.bat")).toString());
+
+		return expectedCommand;
+	}
+
+	private List<String> getExpectedXCommand() {
+		final List<String> expectedCommand = new ArrayList<>();
+		expectedCommand.add(ES_HOME_PATH.resolve(Paths.get("bin", "elasticsearch")).toString());
+		expectedCommand.add(ManagedElasticsearchLifecycleManager.FOREGROUND_OPTION);
+
+		return expectedCommand;
+	}
+}

--- a/nosqlunit-elasticsearch2/src/test/java/com/lordofthejars/nosqlunit/elasticsearch2/integration/WhenEmbeddedElasticsearchOperationsAreRequired.java
+++ b/nosqlunit-elasticsearch2/src/test/java/com/lordofthejars/nosqlunit/elasticsearch2/integration/WhenEmbeddedElasticsearchOperationsAreRequired.java
@@ -1,0 +1,108 @@
+package com.lordofthejars.nosqlunit.elasticsearch2.integration;
+
+import com.lordofthejars.nosqlunit.elasticsearch2.ElasticsearchOperation;
+import com.lordofthejars.nosqlunit.elasticsearch2.EmbeddedElasticsearch;
+import com.lordofthejars.nosqlunit.elasticsearch2.EmbeddedElasticsearchInstancesFactory;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.node.Node;
+import org.junit.After;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.util.Map;
+
+import static com.lordofthejars.nosqlunit.elasticsearch2.EmbeddedElasticsearch.EmbeddedElasticsearchRuleBuilder.newEmbeddedElasticsearchRule;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.collection.IsMapContaining.hasEntry;
+import static org.junit.Assert.assertThat;
+
+public class WhenEmbeddedElasticsearchOperationsAreRequired {
+	private static final String ELASTICSEARCH_DATA = "{\n" +
+			"   \"documents\":[\n" +
+			"	  {\n" +
+			"		 \"document\":[\n" +
+			"			{\n" +
+			"			   \"index\":{\n" +
+			"				  \"indexName\":\"tweeter\",\n" +
+			"				  \"indexType\":\"tweet\",\n" +
+			"				  \"indexId\":\"1\"\n" +
+			"			   }\n" +
+			"			},\n" +
+			"			{\n" +
+			"			   \"data\":{\n" +
+			"				  \"name\":\"a\",\n" +
+			"				  \"msg\":\"b\"\n" +
+			"			   }\n" +
+			"			}\n" +
+			"		 ]\n" +
+			"	  }\n" +
+			"   ]\n" +
+			"}";
+
+	@ClassRule
+	public static final EmbeddedElasticsearch EMBEDDED_ELASTICSEARCH = newEmbeddedElasticsearchRule().build();
+
+	@After
+	public void removeIndexes() {
+		Node defaultEmbeddedInstance = EmbeddedElasticsearchInstancesFactory.getInstance().getDefaultEmbeddedInstance();
+
+		try (final Client client = defaultEmbeddedInstance.client()) {
+			client.admin().indices().prepareDelete("*").execute().actionGet();
+			client.admin().indices().prepareRefresh().execute().actionGet();
+		}
+	}
+
+	@Test
+	public void insert_operation_should_index_all_dataset() {
+
+		Node defaultEmbeddedInstance = EmbeddedElasticsearchInstancesFactory.getInstance().getDefaultEmbeddedInstance();
+		Client client = defaultEmbeddedInstance.client();
+
+		ElasticsearchOperation elasticsearchOperation = new ElasticsearchOperation(client);
+		elasticsearchOperation.insert(new ByteArrayInputStream(ELASTICSEARCH_DATA.getBytes()));
+
+		GetResponse document = client.prepareGet("tweeter", "tweet", "1").execute().actionGet();
+		Map<String, Object> documentSource = document.getSource();
+
+		//Strange a cast to Object
+		assertThat(documentSource, hasEntry("name", (Object) "a"));
+		assertThat(documentSource, hasEntry("msg", (Object) "b"));
+
+		client.close();
+	}
+
+	@Test
+	public void delete_operation_should_remove_all_Indexes() {
+
+		Node defaultEmbeddedInstance = EmbeddedElasticsearchInstancesFactory.getInstance().getDefaultEmbeddedInstance();
+		Client client = defaultEmbeddedInstance.client();
+
+		ElasticsearchOperation elasticsearchOperation = new ElasticsearchOperation(client);
+		elasticsearchOperation.insert(new ByteArrayInputStream(ELASTICSEARCH_DATA.getBytes()));
+
+		elasticsearchOperation.deleteAll();
+
+		GetResponse document = client.prepareGet("tweeter", "tweet", "1").execute().actionGet();
+		assertThat(document.isSourceEmpty(), is(true));
+
+		client.close();
+	}
+
+	@Test
+	public void databaseIs_operation_should_compare_all_Indexes() {
+
+		Node defaultEmbeddedInstance = EmbeddedElasticsearchInstancesFactory.getInstance().getDefaultEmbeddedInstance();
+		Client client = defaultEmbeddedInstance.client();
+
+		ElasticsearchOperation elasticsearchOperation = new ElasticsearchOperation(client);
+		elasticsearchOperation.insert(new ByteArrayInputStream(ELASTICSEARCH_DATA.getBytes()));
+
+		boolean isEqual = elasticsearchOperation.databaseIs(new ByteArrayInputStream(ELASTICSEARCH_DATA.getBytes()));
+
+		assertThat(isEqual, is(true));
+
+		client.close();
+	}
+}

--- a/nosqlunit-elasticsearch2/src/test/java/com/lordofthejars/nosqlunit/elasticsearch2/integration/WhenExpectedDataShouldBeCompared.java
+++ b/nosqlunit-elasticsearch2/src/test/java/com/lordofthejars/nosqlunit/elasticsearch2/integration/WhenExpectedDataShouldBeCompared.java
@@ -1,0 +1,191 @@
+package com.lordofthejars.nosqlunit.elasticsearch2.integration;
+
+import com.lordofthejars.nosqlunit.elasticsearch2.ElasticsearchOperation;
+import com.lordofthejars.nosqlunit.elasticsearch2.EmbeddedElasticsearch;
+import com.lordofthejars.nosqlunit.elasticsearch2.EmbeddedElasticsearchInstancesFactory;
+import com.lordofthejars.nosqlunit.core.NoSqlAssertionError;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.node.Node;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+
+import static com.lordofthejars.nosqlunit.elasticsearch2.EmbeddedElasticsearch.EmbeddedElasticsearchRuleBuilder.newEmbeddedElasticsearchRule;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class WhenExpectedDataShouldBeCompared {
+
+	private static final String ELASTICSEARCH_DATA = "{\n" +
+			"   \"documents\":[\n" +
+			"	  {\n" +
+			"		 \"document\":[\n" +
+			"			{\n" +
+			"			   \"index\":{\n" +
+			"				  \"indexName\":\"tweeter\",\n" +
+			"				  \"indexType\":\"tweet\",\n" +
+			"				  \"indexId\":\"1\"\n" +
+			"			   }\n" +
+			"			},\n" +
+			"			{\n" +
+			"			   \"data\":{\n" +
+			"				  \"name\":\"a\",\n" +
+			"				  \"msg\":\"b\"\n" +
+			"			   }\n" +
+			"			}\n" +
+			"		 ]\n" +
+			"	  }\n" +
+			"   ]\n" +
+			"}";
+
+	private static final String ELASTICSEARCH_TWO_DATA = "{\n" +
+			"   \"documents\":[\n" +
+			"	  {\n" +
+			"		 \"document\":[\n" +
+			"			{\n" +
+			"			   \"index\":{\n" +
+			"				  \"indexName\":\"tweeter\",\n" +
+			"				  \"indexType\":\"tweet\",\n" +
+			"				  \"indexId\":\"1\"\n" +
+			"			   }\n" +
+			"			},\n" +
+			"			{\n" +
+			"			   \"data\":{\n" +
+			"				  \"name\":\"a\",\n" +
+			"				  \"msg\":\"b\"\n" +
+			"			   }\n" +
+			"			}\n" +
+			"		 ]\n" +
+			"	  },\n" +
+			"	  {\n" +
+			"		 \"document\":[\n" +
+			"			{\n" +
+			"			   \"index\":{\n" +
+			"				  \"indexName\":\"tweeter\",\n" +
+			"				  \"indexType\":\"tweet\",\n" +
+			"				  \"indexId\":\"2\"\n" +
+			"			   }\n" +
+			"			},\n" +
+			"			{\n" +
+			"			   \"data\":{\n" +
+			"				  \"name\":\"c\",\n" +
+			"				  \"msg\":\"d\"\n" +
+			"			   }\n" +
+			"			}\n" +
+			"		 ]\n" +
+			"	  }\n" +
+			"   ]\n" +
+			"}";
+
+	private static final String ELASTICSEARCH_DATA_INDEX_NOT_FOUND = "{\n" +
+			"   \"documents\":[\n" +
+			"	  {\n" +
+			"		 \"document\":[\n" +
+			"			{\n" +
+			"			   \"index\":{\n" +
+			"				  \"indexName\":\"tweeter\",\n" +
+			"				  \"indexType\":\"tweet\",\n" +
+			"				  \"indexId\":\"2\"\n" +
+			"			   }\n" +
+			"			},\n" +
+			"			{\n" +
+			"			   \"data\":{\n" +
+			"				  \"name\":\"a\",\n" +
+			"				  \"msg\":\"b\"\n" +
+			"			   }\n" +
+			"			}\n" +
+			"		 ]\n" +
+			"	  }\n" +
+			"   ]\n" +
+			"}";
+
+	private static final String ELASTICSEARCH_DATA_NOT_FOUND = "{\n" +
+			"   \"documents\":[\n" +
+			"	  {\n" +
+			"		 \"document\":[\n" +
+			"			{\n" +
+			"			   \"index\":{\n" +
+			"				  \"indexName\":\"tweeter\",\n" +
+			"				  \"indexType\":\"tweet\",\n" +
+			"				  \"indexId\":\"1\"\n" +
+			"			   }\n" +
+			"			},\n" +
+			"			{\n" +
+			"			   \"data\":{\n" +
+			"				  \"name\":\"a\",\n" +
+			"				  \"msg\":\"c\"\n" +
+			"			   }\n" +
+			"			}\n" +
+			"		 ]\n" +
+			"	  }\n" +
+			"   ]\n" +
+			"}";
+
+	@ClassRule
+	public static EmbeddedElasticsearch embeddedElasticsearch = newEmbeddedElasticsearchRule().build();
+
+	private ElasticsearchOperation elasticsearchOperation;
+
+	@Before
+	public void setUp() {
+		Node defaultEmbeddedInstance = EmbeddedElasticsearchInstancesFactory.getInstance().getDefaultEmbeddedInstance();
+		Client client = defaultEmbeddedInstance.client();
+
+		elasticsearchOperation = new ElasticsearchOperation(client);
+		elasticsearchOperation.deleteAll();
+	}
+
+	@Test
+	public void no_exception_should_be_thrown_if_data_is_expected() {
+
+		elasticsearchOperation.insert(new ByteArrayInputStream(ELASTICSEARCH_DATA.getBytes()));
+
+		boolean result = elasticsearchOperation.databaseIs(new ByteArrayInputStream(ELASTICSEARCH_DATA.getBytes()));
+
+		assertThat(result, is(true));
+
+	}
+
+	@Test
+	public void exception_should_be_thrown_if_different_number_of_documents() {
+
+		elasticsearchOperation.insert(new ByteArrayInputStream(ELASTICSEARCH_DATA.getBytes()));
+
+		try {
+			elasticsearchOperation.databaseIs(new ByteArrayInputStream(ELASTICSEARCH_TWO_DATA.getBytes()));
+			fail();
+		} catch (NoSqlAssertionError e) {
+			assertThat(e.getMessage(), is("Expected number of documents are 2 but 1 has been found."));
+		}
+	}
+
+	@Test
+	public void exception_should_be_thrown_if_index_not_found() {
+
+		elasticsearchOperation.insert(new ByteArrayInputStream(ELASTICSEARCH_DATA.getBytes()));
+
+		try {
+			elasticsearchOperation.databaseIs(new ByteArrayInputStream(ELASTICSEARCH_DATA_INDEX_NOT_FOUND.getBytes()));
+			fail();
+		} catch (NoSqlAssertionError e) {
+			assertThat(e.getMessage(), is("Document with index: tweeter - type: tweet - id: 2 has not returned any document."));
+		}
+	}
+
+	@Test
+	public void exception_should_be_thrown_if_different_() {
+
+		elasticsearchOperation.insert(new ByteArrayInputStream(ELASTICSEARCH_DATA.getBytes()));
+
+		try {
+			elasticsearchOperation.databaseIs(new ByteArrayInputStream(ELASTICSEARCH_DATA_NOT_FOUND.getBytes()));
+			fail();
+		} catch (NoSqlAssertionError e) {
+			assertThat(e.getMessage(), is("Expected document for index: tweeter - type: tweet - id: 1 is {\"name\":\"a\",\"msg\":\"c\"}, but {\"name\":\"a\",\"msg\":\"b\"} was found."));
+		}
+	}
+
+}

--- a/nosqlunit-elasticsearch2/src/test/java/com/lordofthejars/nosqlunit/elasticsearch2/integration/WhenManagedElasticsearchOperationsAreRequired.java
+++ b/nosqlunit-elasticsearch2/src/test/java/com/lordofthejars/nosqlunit/elasticsearch2/integration/WhenManagedElasticsearchOperationsAreRequired.java
@@ -1,0 +1,102 @@
+package com.lordofthejars.nosqlunit.elasticsearch2.integration;
+
+import com.lordofthejars.nosqlunit.elasticsearch2.ElasticsearchOperation;
+import com.lordofthejars.nosqlunit.elasticsearch2.ManagedElasticsearch;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.common.transport.InetSocketTransportAddress;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.net.InetSocketAddress;
+import java.util.Map;
+
+import static com.lordofthejars.nosqlunit.elasticsearch2.ManagedElasticsearch.ManagedElasticsearchRuleBuilder.newManagedElasticsearchRule;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.collection.IsMapContaining.hasEntry;
+import static org.junit.Assert.assertThat;
+
+public class WhenManagedElasticsearchOperationsAreRequired {
+	private static final String ELASTICSEARCH_DATA = "{\n" +
+			"   \"documents\":[\n" +
+			"	  {\n" +
+			"		 \"document\":[\n" +
+			"			{\n" +
+			"			   \"index\":{\n" +
+			"				  \"indexName\":\"tweeter\",\n" +
+			"				  \"indexType\":\"tweet\",\n" +
+			"				  \"indexId\":\"1\"\n" +
+			"			   }\n" +
+			"			},\n" +
+			"			{\n" +
+			"			   \"data\":{\n" +
+			"				  \"name\":\"a\",\n" +
+			"				  \"msg\":\"b\"\n" +
+			"			   }\n" +
+			"			}\n" +
+			"		 ]\n" +
+			"	  }\n" +
+			"   ]\n" +
+			"}";
+
+
+	@ClassRule
+	public static ManagedElasticsearch managedElasticsearch = newManagedElasticsearchRule().elasticsearchPath("/usr/local/Cellar/elasticsearch/1.3.2/").build();
+
+	private static final InetSocketAddress INET_SOCKET_ADDRESS = new InetSocketAddress("localhost", 9300);
+	private static final InetSocketTransportAddress TRANSPORT_ADDRESS = new InetSocketTransportAddress(INET_SOCKET_ADDRESS);
+
+	private Client client;
+
+	@Before
+	public void setupClient() {
+		client = TransportClient.builder().build().addTransportAddress(TRANSPORT_ADDRESS);
+	}
+
+
+	@After
+	public void removeIndexes() {
+		client.admin().indices().prepareDelete("*").execute().actionGet();
+		client.admin().indices().prepareRefresh().execute().actionGet();
+
+		client.close();
+	}
+
+	@Test
+	public void insert_operation_should_index_all_dataset() {
+		ElasticsearchOperation elasticsearchOperation = new ElasticsearchOperation(client);
+		elasticsearchOperation.insert(new ByteArrayInputStream(ELASTICSEARCH_DATA.getBytes()));
+
+		GetResponse document = client.prepareGet("tweeter", "tweet", "1").execute().actionGet();
+		Map<String, Object> documentSource = document.getSource();
+
+		//Strange a cast to Object
+		assertThat(documentSource, hasEntry("name", (Object) "a"));
+		assertThat(documentSource, hasEntry("msg", (Object) "b"));
+	}
+
+	@Test
+	public void delete_operation_should_remove_all_Indexes() {
+		ElasticsearchOperation elasticsearchOperation = new ElasticsearchOperation(client);
+		elasticsearchOperation.insert(new ByteArrayInputStream(ELASTICSEARCH_DATA.getBytes()));
+
+		elasticsearchOperation.deleteAll();
+
+		GetResponse document = client.prepareGet("tweeter", "tweet", "1").execute().actionGet();
+		assertThat(document.isSourceEmpty(), is(true));
+	}
+
+	@Test
+	public void databaseIs_operation_should_compare_all_Indexes() {
+		ElasticsearchOperation elasticsearchOperation = new ElasticsearchOperation(client);
+		elasticsearchOperation.insert(new ByteArrayInputStream(ELASTICSEARCH_DATA.getBytes()));
+
+		boolean isEqual = elasticsearchOperation.databaseIs(new ByteArrayInputStream(ELASTICSEARCH_DATA.getBytes()));
+
+		assertThat(isEqual, is(true));
+	}
+}

--- a/nosqlunit-elasticsearch2/src/test/java/com/lordofthejars/nosqlunit/elasticsearch2/integration/parser/WhenElasticsearchDataIsImported.java
+++ b/nosqlunit-elasticsearch2/src/test/java/com/lordofthejars/nosqlunit/elasticsearch2/integration/parser/WhenElasticsearchDataIsImported.java
@@ -1,0 +1,63 @@
+package com.lordofthejars.nosqlunit.elasticsearch2.integration.parser;
+
+import com.lordofthejars.nosqlunit.elasticsearch2.parser.DataReader;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.node.Node;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Map;
+
+import static org.elasticsearch.node.NodeBuilder.nodeBuilder;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class WhenElasticsearchDataIsImported {
+	private static final String ELASTICSEARCH_DATA = "{\n" +
+			"   \"documents\":[\n" +
+			"	  {\n" +
+			"		 \"document\":[\n" +
+			"			{\n" +
+			"			   \"index\":{\n" +
+			"				  \"indexName\":\"tweeter\",\n" +
+			"				  \"indexType\":\"tweet\",\n" +
+			"				  \"indexId\":\"1\"\n" +
+			"			   }\n" +
+			"			},\n" +
+			"			{\n" +
+			"			   \"data\":{\n" +
+			"				  \"name\":\"a\",\n" +
+			"				  \"msg\":\"b\"\n" +
+			"			   }\n" +
+			"			}\n" +
+			"		 ]\n" +
+			"	  }\n" +
+			"   ]\n" +
+			"}";
+
+	@Rule
+	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@Test
+	public void data_should_be_indexed() throws IOException {
+		final String pathHome = temporaryFolder.newFolder().getAbsolutePath();
+		final Settings settings = nodeBuilder().settings().put("path.home", pathHome).build();
+
+		try (final Node node = nodeBuilder().local(true).settings(settings).node();
+			 final Client client = node.client()) {
+			final DataReader dataReader = new DataReader(client);
+			dataReader.read(new ByteArrayInputStream(ELASTICSEARCH_DATA.getBytes()));
+
+			final GetResponse response = client.prepareGet("tweeter", "tweet", "1").execute().actionGet();
+			final Map<String, Object> document = response.getSourceAsMap();
+
+			assertThat((String) document.get("name"), is("a"));
+			assertThat((String) document.get("msg"), is("b"));
+		}
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<mongo.version>3.0.1</mongo.version>
 		<elasticsearch.version>1.1.1</elasticsearch.version>
+		<elasticsearch2.version>2.0.2</elasticsearch2.version>
 		<junit.version>4.11</junit.version>
 		<hamcrest.version>1.3</hamcrest.version>
 		<mockito.version>1.9.0</mockito.version>
@@ -333,6 +334,7 @@
 		<module>nosqlunit-couchdb</module>
 		<module>nosqlunit-infinispan</module>
 		<module>nosqlunit-elasticsearch</module>
+		<module>nosqlunit-elasticsearch2</module>
 		<module>nosqlunit-couchbase</module>
 	</modules>
 


### PR DESCRIPTION
This PR imports the 3rd party project to support Elasticsearch 2.x from https://github.com/joschi/nosqlunit-elasticsearch2

The module is currently using Elasticsearch 2.0.2 as baseline but would also work with newer versions of Elasticsearch 2.x.

Refs joschi/nosqlunit-elasticsearch2#1