### PR TITLE
Update DefaultInsertionStrategy.java

### DIFF
--- a/nosqlunit-mongodb/src/main/java/com/lordofthejars/nosqlunit/mongodb/DefaultInsertionStrategy.java
+++ b/nosqlunit-mongodb/src/main/java/com/lordofthejars/nosqlunit/mongodb/DefaultInsertionStrategy.java
@@ -115,12 +115,12 @@ public class DefaultInsertionStrategy implements MongoInsertionStrategy {
         if (data instanceof DBRef) {
           ((DBObject)dataObject).put(key, new DBRef(((DBRef)data).getCollectionName(), ((DBRef)data).getId()));
         } else if(data instanceof BasicDBList) {
-            for (Object subData : (BasicDBList) data) {
-                for (String subKey : ((DBObject)data).keySet()) {
+            BasicDBList	dataDBList = (BasicDBList) data;
+            for (Object subData : dataDBList) {
                     if(subData instanceof DBRef) {
+                    	String subKey = String.valueOf(dataDBList.indexOf(subData));
                         ((BasicDBList)data).put(subKey, new DBRef(((DBRef)subData).getCollectionName(), ((DBRef)subData).getId()));
                     }
-                }
 
             }
         }


### PR DESCRIPTION
Give the posibility to insert an array of DBRef. In fact, when having an array of DBRef like 

{...., "contacts":[  
            {  
               "$ref":"user",
               "$id":"2"
            },
            {  
               "$ref":"user",
               "$id":"1"
            }
         ]},
The final document inserted in the Fongo DB repeat the first element of the array  each time you have elements in the array. So with my example , we will have: 
{  "$ref":"user",  "$id":"2" , "$ref":"user",  "$id":"2"   } instead of {  "$ref":"user",  "$id":"2" , "$ref":"user",  "$id":"1"   }
