### PR TITLE
added windows 10 operating system

### DIFF
--- a/nosqlunit-core/src/main/java/com/lordofthejars/nosqlunit/core/OperatingSystem.java
+++ b/nosqlunit-core/src/main/java/com/lordofthejars/nosqlunit/core/OperatingSystem.java
@@ -13,6 +13,7 @@ public enum OperatingSystem {
     WINDOWS_2000 ("Windows 2000",WINDOWS),
     WINDOWS_XP ("Windows XP",WINDOWS),
     WINDOWS_7 ("Windows 7",WINDOWS),
+    WINDOWS_10 ("Windows 10",WINDOWS),
     WINDOWS_2003 ("Windows 2003",WINDOWS),
     WINDOWS_2008 ("Windows 2008",WINDOWS),
     SUN_OS ("Sun OS ",UNIX),


### PR DESCRIPTION
Hi, I'm working on extension for [MarkLogic](https://www.marklogic.com/),
see [here](https://github.com/petrandreev/nosql-unit/tree/add-marklogic-support)
and stumbled upon the missing support for Windows 10 in NoSQLUnit. Therefore the PR.
Cheers 