### PR TITLE
build(ci): setup CI with Travis and Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: java
+
+services:
+  - docker
+
+before_install:
+  - docker --version
+  - docker-compose --version
+  - docker-compose up -d
+  - docker-compose run nosqlunit.wait
+  - docker-compose run nosqlunit.maven mvn -B -Pintegration-tests clean install
+
+cache:
+  directories:
+  - $HOME/.m2
+
+
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-[![Build Status](https://buildhive.cloudbees.com/job/lordofthejars/job/nosql-unit/badge/icon)](https://buildhive.cloudbees.com/job/lordofthejars/job/nosql-unit/)
-
+[![Build Status](https://travis-ci.org/tinesoft/nosql-unit.svg?branch=master)](https://travis-ci.org/lordofthejars/nosql-unit)
 
 Documentation
 =============

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,51 @@
+version: '2.2'
+services:
+
+  nosqlunit-elasticsearch6.elasticsearch:
+    image: elasticsearch:6.7.1
+    environment:
+      - discovery.type=single-node
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    ports:
+      - 9200:9200
+      - 9300:9300
+    networks:
+      nosqlunit-net:
+        aliases: 
+          - elasticsearch6
+  nosqlunit.maven:
+    image: maven:3.6.0-jdk-8-alpine
+    stop_signal: SIGKILL
+    stdin_open: true
+    tty: true
+    working_dir: $PWD
+    volumes:
+      - $PWD:$PWD
+      - /var/run/docker.sock:/var/run/docker.sock
+      # Maven cache (optional)
+      - $HOME/.m2:/root/.m2
+    networks:
+      nosqlunit-net:
+        aliases: 
+          - maven
+  # helper to wait for all services to start before launching test
+  nosqlunit.wait:
+    image: waisbrot/wait
+    depends_on:
+      - nosqlunit.maven
+      - nosqlunit-elasticsearch6.elasticsearch
+
+
+    environment:
+      - TARGETS=elasticsearch6:9200
+    networks:
+      nosqlunit-net:
+        aliases: 
+          - wait
+networks:
+  nosqlunit-net:

--- a/pom.xml
+++ b/pom.xml
@@ -378,7 +378,6 @@
     </modules>
 
     <build>
-
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -389,50 +388,6 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>2.1.2</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.1</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.7</version>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                        <configuration>
-                            <additionalparam>-Xdoclint:none</additionalparam>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
         </plugins>
         <pluginManagement>
             <plugins>
@@ -484,6 +439,56 @@
         </repository>
     </distributionManagement>
     <profiles>
+    	<profile>
+    		<id>release</id>
+		   <build>
+		        <plugins>
+		            <plugin>
+		                <groupId>org.apache.maven.plugins</groupId>
+		                <artifactId>maven-source-plugin</artifactId>
+		                <version>2.1.2</version>
+		                <executions>
+		                    <execution>
+		                        <id>attach-sources</id>
+		                        <goals>
+		                            <goal>jar-no-fork</goal>
+		                        </goals>
+		                    </execution>
+		                </executions>
+		            </plugin>
+		            <plugin>
+		                <groupId>org.apache.maven.plugins</groupId>
+		                <artifactId>maven-gpg-plugin</artifactId>
+		                <version>1.1</version>
+		                <executions>
+		                    <execution>
+		                        <id>sign-artifacts</id>
+		                        <phase>verify</phase>
+		                        <goals>
+		                            <goal>sign</goal>
+		                        </goals>
+		                    </execution>
+		                </executions>
+		            </plugin>
+		            <plugin>
+		                <groupId>org.apache.maven.plugins</groupId>
+		                <artifactId>maven-javadoc-plugin</artifactId>
+		                <version>2.7</version>
+		                <executions>
+		                    <execution>
+		                        <id>attach-javadocs</id>
+		                        <goals>
+		                            <goal>jar</goal>
+		                        </goals>
+		                        <configuration>
+		                            <additionalparam>-Xdoclint:none</additionalparam>
+		                        </configuration>
+		                    </execution>
+		                </executions>
+		            </plugin>
+		        </plugins>
+    		</build>
+    	</profile>
         <profile>
             <id>integration-tests</id>
             <activation>


### PR DESCRIPTION
For the moment, the `docker-compose.yml` only contains `maven `and `elasticsearch6`. I'm still struggling with the others services (in particular elasticsearch1 and 2 => host/port conflicts yet to be resolved).
I'll probably add them later on.